### PR TITLE
Store file URL before extracting metadata

### DIFF
--- a/client/src/app/(main)/page.tsx
+++ b/client/src/app/(main)/page.tsx
@@ -20,7 +20,7 @@ import Link from "next/link";
 import EnigmaticLoadingExperience from "@/components/EnigmaticLoadingExperience";
 import { PaperItem } from "@/components/AppSidebar";
 import PaperCard from "@/components/PaperCard";
-import { JobStatusType } from "@/lib/schema";
+import { JobStatusType, JobStatusResponse } from "@/lib/schema";
 import OpenPaperLanding from "@/components/OpenPaperLanding";
 import { toast } from "sonner";
 import { useSubscription, isStorageAtLimit, isPaperUploadAtLimit, isPaperUploadNearLimit, isStorageNearLimit } from "@/hooks/useSubscription";
@@ -28,17 +28,6 @@ import { useSubscription, isStorageAtLimit, isPaperUploadAtLimit, isPaperUploadN
 interface PdfUploadResponse {
 	message: string;
 	job_id: string;
-}
-
-interface JobStatusResponse {
-	job_id: string;
-	status: JobStatusType;
-	started_at: string;
-	completed_at: string | null;
-	paper_id: string | null;
-	has_file_url: boolean;
-	has_metadata: boolean;
-	celery_progress_message: string | null;
 }
 
 const DEFAULT_PAPER_UPLOAD_ERROR_MESSAGE = "We encountered an error processing your request. Please check the file or URL and try again.";
@@ -197,14 +186,13 @@ export default function Home() {
 				setCeleryMessage(response.celery_progress_message);
 			}
 
-			if (response.status === 'completed' && response.paper_id) {
-
+			if (response.paper_id) {
 				// Success - redirect to paper
 				const redirectUrl = new URL(`/paper/${response.paper_id}`, window.location.origin);
+				redirectUrl.searchParams.append('job_id', jobId);
 				setTimeout(() => {
 					window.location.href = redirectUrl.toString();
 				}, 500);
-
 			} else if (response.status === 'failed') {
 				// Failed - show error
 				console.error('Upload job failed');

--- a/client/src/app/(main)/paper/[id]/page.tsx
+++ b/client/src/app/(main)/paper/[id]/page.tsx
@@ -182,6 +182,37 @@ export default function PaperView() {
 
     const [jobId, setJobId] = useState<string | null>(null);
     const [loadingMessage, setLoadingMessage] = useState<string | null>(null);
+    const [sidePanelDisplayedText, setSidePanelDisplayedText] = useState('');
+    const [isSidePanelTyping, setIsSidePanelTyping] = useState(false);
+
+    useEffect(() => {
+        if (!jobId) {
+            setSidePanelDisplayedText('');
+            setIsSidePanelTyping(false);
+            return;
+        }
+        if (!loadingMessage) {
+            setSidePanelDisplayedText('Processing your paper...');
+            setIsSidePanelTyping(false);
+            return;
+        }
+
+        let charIndex = 0;
+        setSidePanelDisplayedText('');
+        setIsSidePanelTyping(true);
+
+        const typingInterval = setInterval(() => {
+            if (charIndex < loadingMessage.length) {
+                setSidePanelDisplayedText(loadingMessage.slice(0, charIndex + 1));
+                charIndex++;
+            } else {
+                setIsSidePanelTyping(false);
+                clearInterval(typingInterval);
+            }
+        }, 50); // 50ms per character for smooth typing
+
+        return () => clearInterval(typingInterval);
+    }, [loadingMessage, jobId]);
 
     useEffect(() => {
         const url = new URL(window.location.href);
@@ -1273,9 +1304,15 @@ export default function PaperView() {
                     style={rightSideFunction !== 'Focus' ? { width: `${100 - leftPanelWidth}%` } : { width: 'auto' }}
                 >
                     {jobId ? (
-                        <div className="flex flex-col items-center justify-center h-full w-full">
-                            <EnigmaticLoadingExperience />
-                            <p className="mt-4 text-lg">{loadingMessage || 'Processing your paper...'}</p>
+                        <div className="flex items-center justify-center h-full w-full">
+                            <div className="flex flex-col items-center">
+                                <EnigmaticLoadingExperience />
+                                <p className="mt-4 text-lg">{sidePanelDisplayedText}
+                                    {isSidePanelTyping && (
+                                        <span className="animate-pulse">|</span>
+                                    )}
+                                </p>
+                            </div>
                         </div>
                     ) : (
                         <>

--- a/client/src/app/(main)/paper/[id]/page.tsx
+++ b/client/src/app/(main)/paper/[id]/page.tsx
@@ -67,6 +67,8 @@ import {
     PaperHighlight,
     Reference,
     ResponseStyle,
+    JobStatusType,
+    JobStatusResponse,
 } from '@/lib/schema';
 
 import { Input } from '@/components/ui/input';
@@ -79,6 +81,7 @@ import Link from 'next/link';
 import { HoverCard, HoverCardContent, HoverCardTrigger } from '@/components/ui/hover-card';
 import { ChatMessageActions } from '@/components/ChatMessageActions';
 import { PaperSidebar } from '@/components/PaperSidebar';
+import EnigmaticLoadingExperience from '@/components/EnigmaticLoadingExperience';
 
 interface ChatRequestBody {
     user_query: string;
@@ -141,7 +144,7 @@ export default function PaperView() {
         handleTextSelection,
         addHighlight,
         removeHighlight,
-        loadHighlights
+        fetchHighlights
     } = useHighlights(id);
 
     const {
@@ -150,6 +153,7 @@ export default function PaperView() {
         removeAnnotation,
         updateAnnotation,
         renderAnnotations,
+        refreshAnnotations,
     } = useAnnotations(id);
 
     const messagesContainerRef = useRef<HTMLDivElement>(null);
@@ -175,6 +179,37 @@ export default function PaperView() {
     const [currentLoadingMessageIndex, setCurrentLoadingMessageIndex] = useState(0);
     const [displayedText, setDisplayedText] = useState('');
     const [isTyping, setIsTyping] = useState(false);
+
+    const [jobId, setJobId] = useState<string | null>(null);
+    const [loadingMessage, setLoadingMessage] = useState<string | null>(null);
+
+    useEffect(() => {
+        const url = new URL(window.location.href);
+        const jobIdFromUrl = url.searchParams.get('job_id');
+        if (jobIdFromUrl) {
+            setJobId(jobIdFromUrl);
+            pollJobStatus(jobIdFromUrl);
+        }
+    }, []);
+
+    const pollJobStatus = async (jobId: string) => {
+        try {
+            const response: JobStatusResponse = await fetchFromApi(`/api/paper/upload/status/${jobId}`);
+            setLoadingMessage(response.celery_progress_message);
+
+            if (response.status === 'completed') {
+                setJobId(null);
+            } else if (response.status === 'failed') {
+                setJobId(null);
+                // Handle failed job
+                console.error('Upload job failed');
+            } else {
+                setTimeout(() => pollJobStatus(jobId), 2000);
+            }
+        } catch (error) {
+            console.error('Error polling job status:', error);
+        }
+    };
 
     // Chat credit usage state
     const [creditUsage, setCreditUsage] = useState<{
@@ -460,10 +495,14 @@ export default function PaperView() {
             }
         }
 
+        if (jobId) return;
+
         fetchPaperNote();
         fetchAvailableModels();
         fetchPaper();
-    }, [id]);
+        refreshAnnotations();
+        fetchHighlights();
+    }, [id, jobId]);
 
     useEffect(() => {
         if (!paperData) return;
@@ -1204,7 +1243,7 @@ export default function PaperView() {
                                 setActiveHighlight={setActiveHighlight}
                                 activeHighlight={activeHighlight}
                                 addHighlight={addHighlight}
-                                loadHighlights={loadHighlights}
+                                loadHighlights={fetchHighlights}
                                 removeHighlight={removeHighlight}
                                 handleTextSelection={handleTextSelection}
                                 renderAnnotations={renderAnnotations}
@@ -1230,523 +1269,532 @@ export default function PaperView() {
 
                 {/* Right Side Panel */}
                 <div
-                    className="flex flex-row h-full relative pr-[60px]"
+                    className={`flex flex-row h-full relative ${!jobId ? "pr-[60px]" : ""}`}
                     style={rightSideFunction !== 'Focus' ? { width: `${100 - leftPanelWidth}%` } : { width: 'auto' }}
                 >
-                    {
-                        rightSideFunction !== 'Focus' && (
-                            <div className="flex-grow h-full overflow-hidden">
-                                {
-                                    rightSideFunction === 'Notes' && (
-                                        <div className='p-2 w-full h-full flex flex-col'>
-                                            <div className="flex justify-between items-center mb-2 flex-shrink-0">
-                                                <div className="flex items-center gap-2">
-                                                    <div className="text-xs text-gray">
-                                                        Length: {paperNoteContent?.length} characters
-                                                    </div>
-                                                    <TooltipProvider>
-                                                        <Tooltip>
-                                                            <TooltipTrigger>
-                                                                <HelpCircle className="h-4 w-4 text-gray-500" />
-                                                            </TooltipTrigger>
-                                                            <TooltipContent>
-                                                                <p>Supports Markdown formatting:</p>
-                                                                <ul className="text-xs mt-1">
-                                                                    <li>**bold**</li>
-                                                                    <li>*italic*</li>
-                                                                    <li># Heading</li>
-                                                                    <li>- List items</li>
-                                                                    <li>{">"} Blockquotes</li>
-                                                                </ul>
-                                                            </TooltipContent>
-                                                        </Tooltip>
-                                                    </TooltipProvider>
-                                                </div>
-                                                <TooltipProvider>
-                                                    <Tooltip>
-                                                        <TooltipTrigger>
-
-                                                            <Toggle
-                                                                aria-label="Toggle markdown preview"
-                                                                onPressedChange={(pressed) => setIsMarkdownPreview(pressed)}
-                                                                pressed={isMarkdownPreview}
-                                                            >
-                                                                <CommandShortcut>
-                                                                    {localizeCommandToOS('M')}
-                                                                </CommandShortcut>
-                                                                {isMarkdownPreview ? <Eye size={16} /> : <Edit size={16} />}
-                                                            </Toggle>
-                                                        </TooltipTrigger>
-                                                        <TooltipContent>
-                                                            <p>Toggle between edit and preview mode</p>
-                                                        </TooltipContent>
-                                                    </Tooltip>
-                                                </TooltipProvider>
-                                            </div>
-
-                                            {isMarkdownPreview ? (
-                                                <div className="flex-1 min-h-0 relative">
-                                                    <div className="absolute inset-0 overflow-y-auto">
-                                                        <div className="prose dark:prose-invert !max-w-full text-sm">
-                                                            <Markdown
-                                                                remarkPlugins={[[remarkMath, { singleDollarTextMath: false }], remarkGfm]}
-                                                                rehypePlugins={[rehypeKatex]}
-                                                            >
-                                                                {paperNoteContent || ''}
-                                                            </Markdown>
+                    {jobId ? (
+                        <div className="flex flex-col items-center justify-center h-full w-full">
+                            <EnigmaticLoadingExperience />
+                            <p className="mt-4 text-lg">{loadingMessage || 'Processing your paper...'}</p>
+                        </div>
+                    ) : (
+                        <>
+                            {
+                                rightSideFunction !== 'Focus' && (
+                                    <div className="flex-grow h-full overflow-hidden">
+                                        {
+                                            rightSideFunction === 'Notes' && (
+                                                <div className='p-2 w-full h-full flex flex-col'>
+                                                    <div className="flex justify-between items-center mb-2 flex-shrink-0">
+                                                        <div className="flex items-center gap-2">
+                                                            <div className="text-xs text-gray">
+                                                                Length: {paperNoteContent?.length} characters
+                                                            </div>
+                                                            <TooltipProvider>
+                                                                <Tooltip>
+                                                                    <TooltipTrigger>
+                                                                        <HelpCircle className="h-4 w-4 text-gray-500" />
+                                                                    </TooltipTrigger>
+                                                                    <TooltipContent>
+                                                                        <p>Supports Markdown formatting:</p>
+                                                                        <ul className="text-xs mt-1">
+                                                                            <li>**bold**</li>
+                                                                            <li>*italic*</li>
+                                                                            <li># Heading</li>
+                                                                            <li>- List items</li>
+                                                                            <li>{">"} Blockquotes</li>
+                                                                        </ul>
+                                                                    </TooltipContent>
+                                                                </Tooltip>
+                                                            </TooltipProvider>
                                                         </div>
-                                                    </div>
-                                                </div>
-                                            ) : (
-                                                <Textarea
-                                                    className='w-full flex-1'
-                                                    value={paperNoteContent}
-                                                    onChange={handleNotesChange}
-                                                    placeholder="Start taking notes..."
-                                                />
-                                            )}
+                                                        <TooltipProvider>
+                                                            <Tooltip>
+                                                                <TooltipTrigger>
 
-                                            {paperNoteContent && lastPaperNoteSaveTime && (
-                                                <div className="text-xs text-green-500 mt-2 flex-shrink-0">
-                                                    Last saved: {new Date(lastPaperNoteSaveTime).toLocaleTimeString()}
-                                                </div>
-                                            )}
-                                        </div>
-                                    )
-                                }
-                                {
-                                    rightSideFunction === 'Annotations' && (
-                                        <div className="flex flex-col h-[calc(100vh-64px)] px-2 overflow-y-auto">
-                                            <AnnotationsView
-                                                annotations={annotations}
-                                                highlights={highlights}
-                                                onHighlightClick={handleHighlightClick}
-                                                addAnnotation={addAnnotation}
-                                                activeHighlight={activeHighlight}
-                                                updateAnnotation={updateAnnotation}
-                                                removeAnnotation={removeAnnotation}
-                                            />
-                                        </div>
-                                    )
-                                }
-                                {
-                                    rightSideFunction === 'Share' && paperData && (
-                                        <div className="flex flex-col h-[calc(100vh-64px)] p-4 space-y-4">
-                                            <h3 className="text-lg font-semibold">Share Paper</h3>
-                                            {paperData.share_id ? (
-                                                <div className="space-y-3">
-                                                    <p className="text-sm text-muted-foreground">This paper is currently public. Anyone with the link can view it.</p>
-                                                    <div className="flex items-center space-x-2">
-                                                        <Input
-                                                            readOnly
-                                                            value={`${window.location.origin}/paper/share/${paperData.share_id}`}
-                                                            className="flex-1"
-                                                        />
-                                                        <Button
-                                                            variant="outline"
-                                                            size="sm"
-                                                            onClick={async () => {
-                                                                await navigator.clipboard.writeText(`${window.location.origin}/paper/share/${paperData.share_id}`);
-                                                                toast.success("Link copied!");
-                                                            }}
-                                                        >
-                                                            Copy Link
-                                                        </Button>
-                                                    </div>
-                                                    <Button
-                                                        variant="destructive"
-                                                        onClick={handleUnshare}
-                                                        disabled={isSharing}
-                                                        className="w-fit"
-                                                    >
-                                                        {isSharing ? <Loader className="animate-spin mr-2 h-4 w-4" /> : null}
-                                                        <LockIcon /> Make Private
-                                                    </Button>
-                                                </div>
-                                            ) : (
-                                                <div className="space-y-3">
-                                                    <p className="text-sm text-muted-foreground">Make this paper public to share it with others via a unique link. All of your highlights and annotations will be visible to anyone with the link. Your chat and notes remain private.</p>
-                                                    <Button
-                                                        onClick={handleShare}
-                                                        disabled={isSharing}
-                                                        className="w-fit"
-                                                    >
-                                                        {isSharing ? <Loader className="animate-spin mr-2 h-4 w-4" /> : null}
-                                                        <Share2Icon /> Share
-                                                    </Button>
-                                                </div>
-                                            )}
-                                        </div>
-                                    )
-                                }
-                                {/* Paper Images Section - Disabled pending extraction improvements */}
-                                {/* {
-                                    rightSideFunction === 'Figures' && (
-                                        <div className="flex flex-col h-[calc(100vh-64px)] px-2 overflow-y-auto">
-                                            <PaperImageView paperId={id} />
-                                        </div>
-                                    )
-                                } */}
-                                {
-                                    rightSideFunction === 'Overview' && paperData.summary && (
-                                        <div className="flex flex-col h-[calc(100vh-64px)] px-2 overflow-y-auto m-2 relative animate-fade-in">
-                                            {/* Paper Metadata Section */}
-                                            <div className="prose dark:prose-invert !max-w-full text-sm">
-                                                {paperData.title && (
-                                                    <h1 className="text-2xl font-bold">{paperData.title}</h1>
-                                                )}
-                                                {memoizedOverviewContent}
-                                                {
-                                                    paperData.summary_citations && paperData.summary_citations.length > 0 && (
-                                                        <div className="mt-0 pt-0 border-t border-gray-300 dark:border-gray-700" id="references-section">
-                                                            <h4 className="text-sm font-semibold mb-2">References</h4>
-                                                            <ul className="list-none p-0">
-                                                                {paperData.summary_citations.map((citation, index) => (
-                                                                    <div
-                                                                        key={index}
-                                                                        className={`flex flex-row gap-2 ${matchesCurrentCitation(`${citation.index}`, 0) ? 'bg-blue-100 dark:bg-blue-900 rounded p-1 transition-colors duration-300' : ''}`}
-                                                                        id={`citation-${citation.index}-${index}`}
-                                                                        onClick={() => handleCitationClickFromSummary(`${citation.index}`, 0)}
+                                                                    <Toggle
+                                                                        aria-label="Toggle markdown preview"
+                                                                        onPressedChange={(pressed) => setIsMarkdownPreview(pressed)}
+                                                                        pressed={isMarkdownPreview}
                                                                     >
-                                                                        <div className={`text-xs text-secondary-foreground`}>
-                                                                            <span>{citation.index}</span>
-                                                                        </div>
-                                                                        <div
-                                                                            id={`citation-ref-${citation.index}-${index}`}
-                                                                            className={`text-xs text-secondary-foreground
-                                                                        }`}>
-                                                                            {citation.text}
-                                                                        </div>
-                                                                    </div>
-                                                                ))}
-                                                            </ul>
-                                                        </div>
-                                                    )}
-                                                <div className="sticky bottom-4 right-4 flex justify-end">
-                                                    <Button
-                                                        variant="default"
-                                                        className="w-fit bg-blue-500 hover:bg-blue-400 dark:hover:bg-blue-600 cursor-pointer z-10 shadow-md"
-                                                        onClick={() => {
-                                                            setRightSideFunction('Chat');
-                                                        }}
-                                                    >
-                                                        <Sparkle className="mr-1" />
-                                                        Ask a Question
-                                                    </Button>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    )
-                                }
-                                {
-                                    rightSideFunction === 'Audio' && (
-                                        <div className="flex flex-col h-[calc(100vh-64px)] px-2 overflow-y-auto">
-                                            <AudioOverview
-                                                paper_id={id}
-                                                paper_title={paperData.title}
-                                                setExplicitSearchTerm={setExplicitSearchTerm} />
-                                        </div>
-                                    )
-                                }
-                                {
-                                    rightSideFunction === 'Chat' && (
-                                        <div className="flex flex-col h-[calc(100vh-64px)] px-2 overflow-y-auto">
-                                            {/* Paper Metadata Section */}
-                                            {paperData && (
-                                                <PaperMetadata
-                                                    paperData={paperData}
-                                                    hasMessages={messages.length > 0}
-                                                    onClickStarterQuestion={(question) => {
-                                                        setCurrentMessage(question);
-                                                        inputMessageRef.current?.focus();
-                                                        chatInputFormRef.current?.scrollIntoView({
-                                                            behavior: 'smooth',
-                                                            block: 'nearest',
-                                                            inline: 'nearest',
-                                                        });
-                                                        setPendingStarterQuestion(question);
-                                                    }}
-                                                />
-                                            )}
-
-                                            <div
-                                                className={`flex-1 overflow-y-auto space-y-2 transition-all duration-300 ease-in-out ${isStreaming ? 'pb-24' : ''}`}
-                                                ref={messagesContainerRef}
-                                                onScroll={handleScroll}
-                                            >
-                                                {hasMoreMessages && messages.length > 0 && (
-                                                    <div className="text-center py-2">
-                                                        {isLoadingMoreMessages ? (
-                                                            <div className="text-sm text-gray-500">Loading messages...</div>
-                                                        ) : (
-                                                            <button
-                                                                className="text-sm text-blue-500 hover:text-blue-700"
-                                                                onClick={fetchMoreMessages}
-                                                            >
-                                                                Load earlier messages
-                                                            </button>
-                                                        )}
+                                                                        <CommandShortcut>
+                                                                            {localizeCommandToOS('M')}
+                                                                        </CommandShortcut>
+                                                                        {isMarkdownPreview ? <Eye size={16} /> : <Edit size={16} />}
+                                                                    </Toggle>
+                                                                </TooltipTrigger>
+                                                                <TooltipContent>
+                                                                    <p>Toggle between edit and preview mode</p>
+                                                                </TooltipContent>
+                                                            </Tooltip>
+                                                        </TooltipProvider>
                                                     </div>
-                                                )}
 
-                                                {messages.length === 0 ? (
-                                                    <div className="text-center text-gray-500 my-4">
-                                                        What do you want to understand about this paper?
-                                                        <div className='grid grid-cols-1 gap-2 mt-2'>
-                                                            {paperData.starter_questions && paperData.starter_questions.length > 0 ? (
-                                                                paperData.starter_questions.slice(0, 5).map((question, i) => (
-                                                                    <Button
-                                                                        key={i}
-                                                                        variant="outline"
-                                                                        className="text-sm font-medium p-2 max-w-full whitespace-normal h-auto text-left justify-start break-words bg-background text-secondary-foreground hover:bg-secondary/50 border-1 hover:translate-y-0.5 transition-transform duration-200"
-                                                                        onClick={() => {
-                                                                            setCurrentMessage(question);
-                                                                            inputMessageRef.current?.focus();
-                                                                            chatInputFormRef.current?.scrollIntoView({
-                                                                                behavior: 'smooth',
-                                                                                block: 'nearest',
-                                                                                inline: 'nearest',
-                                                                            });
-                                                                            setPendingStarterQuestion(question);
-                                                                        }}
+                                                    {isMarkdownPreview ? (
+                                                        <div className="flex-1 min-h-0 relative">
+                                                            <div className="absolute inset-0 overflow-y-auto">
+                                                                <div className="prose dark:prose-invert !max-w-full text-sm">
+                                                                    <Markdown
+                                                                        remarkPlugins={[[remarkMath, { singleDollarTextMath: false }], remarkGfm]}
+                                                                        rehypePlugins={[rehypeKatex]}
                                                                     >
-                                                                        {question}
-                                                                    </Button>
-                                                                ))
-                                                            ) : null}
-                                                        </div>
-                                                    </div>
-                                                ) : (
-                                                    memoizedMessages
-                                                )}
-                                                {
-                                                    isStreaming && streamingChunks.length > 0 && (
-                                                        <div className="relative group prose dark:prose-invert p-2 !max-w-full rounded-lg w-full text-primary dark:text-primary-foreground">
-                                                            <AnimatedMarkdown
-                                                                content={streamingChunks.join('')}
-                                                                remarkPlugins={[[remarkMath, { singleDollarTextMath: false }], remarkGfm]}
-                                                                rehypePlugins={[rehypeKatex]}
-                                                                components={{
-                                                                    // Apply the custom component to text nodes
-                                                                    p: (props) => <CustomCitationLink
-                                                                        {...props}
-                                                                        handleCitationClick={handleCitationClick}
-                                                                        messageIndex={messages.length} // Use the next message index
-                                                                        citations={streamingReferences?.citations || []}
-                                                                    />,
-                                                                    li: (props) => <CustomCitationLink
-                                                                        {...props}
-                                                                        handleCitationClick={handleCitationClick}
-                                                                        messageIndex={messages.length} // Use the next message index
-                                                                        citations={streamingReferences?.citations || []}
-                                                                    />,
-                                                                    div: (props) => <CustomCitationLink
-                                                                        {...props}
-                                                                        handleCitationClick={handleCitationClick}
-                                                                        messageIndex={messages.length} // Use the next message index
-                                                                        citations={streamingReferences?.citations || []}
-                                                                    />,
-                                                                    td: (props) => <CustomCitationLink
-                                                                        {...props}
-                                                                        handleCitationClick={handleCitationClickFromSummary}
-                                                                        messageIndex={0}
-                                                                        citations={streamingReferences?.citations || []}
-                                                                    />,
-                                                                    table: (props) => (
-                                                                        <div className="w-full overflow-x-auto">
-                                                                            <table {...props} className="min-w-full border-collapse" />
-                                                                        </div>
-                                                                    ),
-                                                                }}
-                                                            />
-                                                            <ChatMessageActions message={streamingChunks.join('')} references={streamingReferences} />
-                                                        </div>
-                                                    )
-                                                }
-                                                {
-                                                    isStreaming && (
-                                                        <div className="flex items-center gap-3 p-2">
-                                                            <Loader className="animate-spin w-6 h-6 text-blue-500 flex-shrink-0" />
-                                                            <div className="text-sm text-secondary-foreground">
-                                                                {displayedText}
-                                                                {isTyping && (
-                                                                    <span className="animate-pulse">|</span>
-                                                                )}
+                                                                        {paperNoteContent || ''}
+                                                                    </Markdown>
+                                                                </div>
                                                             </div>
                                                         </div>
-                                                    )
-                                                }
-                                                <div ref={messagesEndRef} />
-                                            </div>
-                                            <form onSubmit={handleSubmit} className="flex flex-col gap-2" ref={chatInputFormRef}>
-                                                {
-                                                    userMessageReferences.length > 0 && (
-                                                        <div className='flex flex-row gap-2'>
-                                                            {userMessageReferences.map((ref, index) => (
-                                                                <div key={index} className="text-xs text-secondary-foreground flex bg-secondary p-2 rounded-lg">
-                                                                    <p
-                                                                        className='
-                                                        overflow-hidden
-                                                        text-ellipsis
-                                                        whitespace-normal
-                                                        max-w-[200px]
-                                                        text-secondary-foreground
-                                                        line-clamp-2
-                                                        '
-                                                                        onClick={() =>
-                                                                            setExplicitSearchTerm(ref)
-                                                                        }
-                                                                    >
-                                                                        {ref}
-                                                                    </p>
-                                                                    <Button
-                                                                        variant='ghost'
-                                                                        className='h-auto w-fit p-0 !px-0'
-                                                                        onClick={() =>
-                                                                            setUserMessageReferences(prev => prev.filter((_, i) => i !== index))
-                                                                        }
-                                                                    >
-                                                                        <X size={2} />
-                                                                    </Button>
-                                                                </div>
-                                                            ))}
-                                                        </div>
-                                                    )
-                                                }
-                                                <div
-                                                    className='rounded-md p-0.5 flex flex-col gap-2 bg-secondary'
-                                                >
-                                                    {/* User message input area */}
-                                                    <Textarea
-                                                        value={currentMessage}
-                                                        onChange={handleTextareaChange}
-                                                        ref={inputMessageRef}
-                                                        placeholder="Ask something about this paper."
-                                                        className="border-none bg-secondary dark:bg-secondary rounded-md resize-none hover:resize-y p-2 focus-visible:outline-none focus-visible:ring-0 shadow-none min-h-[2rem] max-h-32"
-                                                        disabled={isStreaming || (creditUsage?.usagePercentage ?? 0) >= 100}
-                                                        onKeyDown={(e) => {
-                                                            if (e.key === 'Enter' && !e.shiftKey) {
-                                                                e.preventDefault();
-                                                                handleSubmit(e);
-                                                            }
-                                                        }}
-                                                    />
-                                                    <div className="flex flex-row justify-between gap-2">
-                                                        <div className="flex flex-row gap-2">
-                                                            <DropdownMenu>
-                                                                <DropdownMenuTrigger asChild>
-                                                                    <Button
-                                                                        variant="ghost"
-                                                                        className="w-fit text-sm"
-                                                                        title='Settings - Configure model and response style'
-                                                                        disabled={isStreaming}
-                                                                    >
-                                                                        <Route
-                                                                            className="h-4 w-4 text-secondary-foreground"
-                                                                        />
-                                                                    </Button>
-                                                                </DropdownMenuTrigger>
-                                                                <DropdownMenuContent className="w-56">
-                                                                    <DropdownMenuSub>
-                                                                        <DropdownMenuSubTrigger className="flex items-center">
-                                                                            <Sparkle className="mr-2 h-4 w-4" />
-                                                                            <span>Model {selectedModel ? `(${availableModels[selectedModel]})` : ''}</span>
-                                                                        </DropdownMenuSubTrigger>
-                                                                        <DropdownMenuSubContent>
-                                                                            {Object.entries(availableModels).map(([key, value]) => (
-                                                                                <DropdownMenuItem
-                                                                                    key={key}
-                                                                                    onClick={() => setSelectedModel(key)}
-                                                                                    className="flex items-center justify-between"
-                                                                                >
-                                                                                    <span>{value}</span>
-                                                                                    {selectedModel === key && (
-                                                                                        <Check className="h-4 w-4 text-green-500" />
-                                                                                    )}
-                                                                                </DropdownMenuItem>
-                                                                            ))}
-                                                                        </DropdownMenuSubContent>
-                                                                    </DropdownMenuSub>
+                                                    ) : (
+                                                        <Textarea
+                                                            className='w-full flex-1'
+                                                            value={paperNoteContent}
+                                                            onChange={handleNotesChange}
+                                                            placeholder="Start taking notes..."
+                                                        />
+                                                    )}
 
-                                                                    <DropdownMenuSub>
-                                                                        <DropdownMenuSubTrigger className="flex items-center">
-                                                                            <Feather className="mr-2 h-4 w-4" />
-                                                                            <span>Response Style {responseStyle ? `(${responseStyle})` : ''}</span>
-                                                                        </DropdownMenuSubTrigger>
-                                                                        <DropdownMenuSubContent>
-                                                                            {Object.values(ResponseStyle).map((style) => (
-                                                                                <DropdownMenuItem
-                                                                                    key={style}
-                                                                                    onClick={() => {
-                                                                                        setResponseStyle(style);
-                                                                                        setRightSideFunction('Chat');
-                                                                                    }}
-                                                                                    className="flex items-center justify-between"
-                                                                                >
-                                                                                    <span>{style}</span>
-                                                                                    {style === responseStyle && (
-                                                                                        <Check className="h-4 w-4 text-green-500" />
-                                                                                    )}
-                                                                                </DropdownMenuItem>
-                                                                            ))}
-                                                                        </DropdownMenuSubContent>
-                                                                    </DropdownMenuSub>
-                                                                </DropdownMenuContent>
-                                                            </DropdownMenu>
+                                                    {paperNoteContent && lastPaperNoteSaveTime && (
+                                                        <div className="text-xs text-green-500 mt-2 flex-shrink-0">
+                                                            Last saved: {new Date(lastPaperNoteSaveTime).toLocaleTimeString()}
                                                         </div>
-                                                        <Button
-                                                            type="submit"
-                                                            onKeyDown={(e) => {
-                                                                if (e.key === 'Enter' && !e.shiftKey) {
-                                                                    e.preventDefault();
-                                                                    handleSubmit(e);
-                                                                }
-                                                            }}
-                                                            variant="default"
-                                                            className="w-fit rounded-full h-fit !px-2 py-2 bg-blue-500 hover:bg-blue-400"
-                                                            disabled={isStreaming}
-                                                        >
-                                                            <ArrowUp
-                                                                className="h-4 w-4 rounded-full"
-                                                                aria-hidden="true"
-                                                            />
-                                                        </Button>
+                                                    )}
+                                                </div>
+                                            )
+                                        }
+                                        {
+                                            rightSideFunction === 'Annotations' && (
+                                                <div className="flex flex-col h-[calc(100vh-64px)] px-2 overflow-y-auto">
+                                                    <AnnotationsView
+                                                        annotations={annotations}
+                                                        highlights={highlights}
+                                                        onHighlightClick={handleHighlightClick}
+                                                        addAnnotation={addAnnotation}
+                                                        activeHighlight={activeHighlight}
+                                                        updateAnnotation={updateAnnotation}
+                                                        removeAnnotation={removeAnnotation}
+                                                    />
+                                                </div>
+                                            )
+                                        }
+                                        {
+                                            rightSideFunction === 'Share' && paperData && (
+                                                <div className="flex flex-col h-[calc(100vh-64px)] p-4 space-y-4">
+                                                    <h3 className="text-lg font-semibold">Share Paper</h3>
+                                                    {paperData.share_id ? (
+                                                        <div className="space-y-3">
+                                                            <p className="text-sm text-muted-foreground">This paper is currently public. Anyone with the link can view it.</p>
+                                                            <div className="flex items-center space-x-2">
+                                                                <Input
+                                                                    readOnly
+                                                                    value={`${window.location.origin}/paper/share/${paperData.share_id}`}
+                                                                    className="flex-1"
+                                                                />
+                                                                <Button
+                                                                    variant="outline"
+                                                                    size="sm"
+                                                                    onClick={async () => {
+                                                                        await navigator.clipboard.writeText(`${window.location.origin}/paper/share/${paperData.share_id}`);
+                                                                        toast.success("Link copied!");
+                                                                    }}
+                                                                >
+                                                                    Copy Link
+                                                                </Button>
+                                                            </div>
+                                                            <Button
+                                                                variant="destructive"
+                                                                onClick={handleUnshare}
+                                                                disabled={isSharing}
+                                                                className="w-fit"
+                                                            >
+                                                                {isSharing ? <Loader className="animate-spin mr-2 h-4 w-4" /> : null}
+                                                                <LockIcon /> Make Private
+                                                            </Button>
+                                                        </div>
+                                                    ) : (
+                                                        <div className="space-y-3">
+                                                            <p className="text-sm text-muted-foreground">Make this paper public to share it with others via a unique link. All of your highlights and annotations will be visible to anyone with the link. Your chat and notes remain private.</p>
+                                                            <Button
+                                                                onClick={handleShare}
+                                                                disabled={isSharing}
+                                                                className="w-fit"
+                                                            >
+                                                                {isSharing ? <Loader className="animate-spin mr-2 h-4 w-4" /> : null}
+                                                                <Share2Icon /> Share
+                                                            </Button>
+                                                        </div>
+                                                    )}
+                                                </div>
+                                            )
+                                        }
+                                        {/* Paper Images Section - Disabled pending extraction improvements */}
+                                        {/* {
+                                            rightSideFunction === 'Figures' && (
+                                                <div className="flex flex-col h-[calc(100vh-64px)] px-2 overflow-y-auto">
+                                                    <PaperImageView paperId={id} />
+                                                </div>
+                                            )
+                                        } */}
+                                        {
+                                            rightSideFunction === 'Overview' && paperData.summary && (
+                                                <div className="flex flex-col h-[calc(100vh-64px)] px-2 overflow-y-auto m-2 relative animate-fade-in">
+                                                    {/* Paper Metadata Section */}
+                                                    <div className="prose dark:prose-invert !max-w-full text-sm">
+                                                        {paperData.title && (
+                                                            <h1 className="text-2xl font-bold">{paperData.title}</h1>
+                                                        )}
+                                                        {memoizedOverviewContent}
+                                                        {
+                                                            paperData.summary_citations && paperData.summary_citations.length > 0 && (
+                                                                <div className="mt-0 pt-0 border-t border-gray-300 dark:border-gray-700" id="references-section">
+                                                                    <h4 className="text-sm font-semibold mb-2">References</h4>
+                                                                    <ul className="list-none p-0">
+                                                                        {paperData.summary_citations.map((citation, index) => (
+                                                                            <div
+                                                                                key={index}
+                                                                                className={`flex flex-row gap-2 ${matchesCurrentCitation(`${citation.index}`, 0) ? 'bg-blue-100 dark:bg-blue-900 rounded p-1 transition-colors duration-300' : ''}`}
+                                                                                id={`citation-${citation.index}-${index}`}
+                                                                                onClick={() => handleCitationClickFromSummary(`${citation.index}`, 0)}
+                                                                            >
+                                                                                <div className={`text-xs text-secondary-foreground`}>
+                                                                                    <span>{citation.index}</span>
+                                                                                </div>
+                                                                                <div
+                                                                                    id={`citation-ref-${citation.index}-${index}`}
+                                                                                    className={`text-xs text-secondary-foreground
+                                                                                `}>
+                                                                                    {citation.text}
+                                                                                </div>
+                                                                            </div>
+                                                                        ))}
+                                                                    </ul>
+                                                                </div>
+                                                            )}
+                                                        <div className="sticky bottom-4 right-4 flex justify-end">
+                                                            <Button
+                                                                variant="default"
+                                                                className="w-fit bg-blue-500 hover:bg-blue-400 dark:hover:bg-blue-600 cursor-pointer z-10 shadow-md"
+                                                                onClick={() => {
+                                                                    setRightSideFunction('Chat');
+                                                                }}
+                                                            >
+                                                                <Sparkle className="mr-1" />
+                                                                Ask a Question
+                                                            </Button>
+                                                        </div>
                                                     </div>
                                                 </div>
-                                                {/* Chat Credit Usage Display */}
-                                                {creditUsage && creditUsage.showWarning && (
-                                                    <div className={`text-xs px-2 py-1 ${creditUsage.isCritical ? 'text-red-600 dark:text-red-400' : 'text-amber-600 dark:text-amber-400'} justify-between flex`}>
-                                                        <div className="font-semibold">{creditUsage.used} credits used</div>
-                                                        <div className="font-semibold">
-                                                            <HoverCard>
-                                                                <HoverCardTrigger asChild>
-                                                                    <span>{creditUsage.remaining} credits remaining</span>
-                                                                </HoverCardTrigger>
-                                                                <HoverCardContent side="top" className="w-48">
-                                                                    <p className="text-sm">Resets on {nextMonday.toLocaleDateString()}</p>
-                                                                </HoverCardContent>
-                                                            </HoverCard>
-                                                            <Link
-                                                                href="/pricing"
-                                                                className="text-blue-500 hover:text-blue-700 ml-1"
-                                                            >
-                                                                Upgrade
-                                                            </Link>
-                                                        </div>
+                                            )
+                                        }
+                                        {
+                                            rightSideFunction === 'Audio' && (
+                                                <div className="flex flex-col h-[calc(100vh-64px)] px-2 overflow-y-auto">
+                                                    <AudioOverview
+                                                        paper_id={id}
+                                                        paper_title={paperData.title}
+                                                        setExplicitSearchTerm={setExplicitSearchTerm} />
+                                                </div>
+                                            )
+                                        }
+                                        {
+                                            rightSideFunction === 'Chat' && (
+                                                <div className="flex flex-col h-[calc(100vh-64px)] px-2 overflow-y-auto">
+                                                    {/* Paper Metadata Section */}
+                                                    {paperData && (
+                                                        <PaperMetadata
+                                                            paperData={paperData}
+                                                            hasMessages={messages.length > 0}
+                                                            onClickStarterQuestion={(question) => {
+                                                                setCurrentMessage(question);
+                                                                inputMessageRef.current?.focus();
+                                                                chatInputFormRef.current?.scrollIntoView({
+                                                                    behavior: 'smooth',
+                                                                    block: 'nearest',
+                                                                    inline: 'nearest',
+                                                                });
+                                                                setPendingStarterQuestion(question);
+                                                            }}
+                                                        />
+                                                    )}
+
+                                                    <div
+                                                        className={`flex-1 overflow-y-auto space-y-2 transition-all duration-300 ease-in-out ${isStreaming ? 'pb-24' : ''}`}
+                                                        ref={messagesContainerRef}
+                                                        onScroll={handleScroll}
+                                                    >
+                                                        {hasMoreMessages && messages.length > 0 && (
+                                                            <div className="text-center py-2">
+                                                                {isLoadingMoreMessages ? (
+                                                                    <div className="text-sm text-gray-500">Loading messages...</div>
+                                                                ) : (
+                                                                    <button
+                                                                        className="text-sm text-blue-500 hover:text-blue-700"
+                                                                        onClick={fetchMoreMessages}
+                                                                    >
+                                                                        Load earlier messages
+                                                                    </button>
+                                                                )}
+                                                            </div>
+                                                        )}
+
+                                                        {messages.length === 0 ? (
+                                                            <div className="text-center text-gray-500 my-4">
+                                                                What do you want to understand about this paper?
+                                                                <div className='grid grid-cols-1 gap-2 mt-2'>
+                                                                    {paperData.starter_questions && paperData.starter_questions.length > 0 ? (
+                                                                        paperData.starter_questions.slice(0, 5).map((question, i) => (
+                                                                            <Button
+                                                                                key={i}
+                                                                                variant="outline"
+                                                                                className="text-sm font-medium p-2 max-w-full whitespace-normal h-auto text-left justify-start break-words bg-background text-secondary-foreground hover:bg-secondary/50 border-1 hover:translate-y-0.5 transition-transform duration-200"
+                                                                                onClick={() => {
+                                                                                    setCurrentMessage(question);
+                                                                                    inputMessageRef.current?.focus();
+                                                                                    chatInputFormRef.current?.scrollIntoView({
+                                                                                        behavior: 'smooth',
+                                                                                        block: 'nearest',
+                                                                                        inline: 'nearest',
+                                                                                    });
+                                                                                    setPendingStarterQuestion(question);
+                                                                                }}
+                                                                            >
+                                                                                {question}
+                                                                            </Button>
+                                                                        ))
+                                                                    ) : null}
+                                                                </div>
+                                                            </div>
+                                                        ) : (
+                                                            memoizedMessages
+                                                        )}
+                                                        {
+                                                            isStreaming && streamingChunks.length > 0 && (
+                                                                <div className="relative group prose dark:prose-invert p-2 !max-w-full rounded-lg w-full text-primary dark:text-primary-foreground">
+                                                                    <AnimatedMarkdown
+                                                                        content={streamingChunks.join('')}
+                                                                        remarkPlugins={[[remarkMath, { singleDollarTextMath: false }], remarkGfm]}
+                                                                        rehypePlugins={[rehypeKatex]}
+                                                                        components={{
+                                                                            // Apply the custom component to text nodes
+                                                                            p: (props) => <CustomCitationLink
+                                                                                {...props}
+                                                                                handleCitationClick={handleCitationClick}
+                                                                                messageIndex={messages.length} // Use the next message index
+                                                                                citations={streamingReferences?.citations || []}
+                                                                            />,
+                                                                            li: (props) => <CustomCitationLink
+                                                                                {...props}
+                                                                                handleCitationClick={handleCitationClick}
+                                                                                messageIndex={messages.length} // Use the next message index
+                                                                                citations={streamingReferences?.citations || []}
+                                                                            />,
+                                                                            div: (props) => <CustomCitationLink
+                                                                                {...props}
+                                                                                handleCitationClick={handleCitationClick}
+                                                                                messageIndex={messages.length} // Use the next message index
+                                                                                citations={streamingReferences?.citations || []}
+                                                                            />,
+                                                                            td: (props) => <CustomCitationLink
+                                                                                {...props}
+                                                                                handleCitationClick={handleCitationClickFromSummary}
+                                                                                messageIndex={0}
+                                                                                citations={streamingReferences?.citations || []}
+                                                                            />,
+                                                                            table: (props) => (
+                                                                                <div className="w-full overflow-x-auto">
+                                                                                    <table {...props} className="min-w-full border-collapse" />
+                                                                                </div>
+                                                                            ),
+                                                                        }}
+                                                                    />
+                                                                    <ChatMessageActions message={streamingChunks.join('')} references={streamingReferences} />
+                                                                </div>
+                                                            )
+                                                        }
+                                                        {
+                                                            isStreaming && (
+                                                                <div className="flex items-center gap-3 p-2">
+                                                                    <Loader className="animate-spin w-6 h-6 text-blue-500 flex-shrink-0" />
+                                                                    <div className="text-sm text-secondary-foreground">
+                                                                        {displayedText}
+                                                                        {isTyping && (
+                                                                            <span className="animate-pulse">|</span>
+                                                                        )}
+                                                                    </div>
+                                                                </div>
+                                                            )
+                                                        }
+                                                        <div ref={messagesEndRef} />
                                                     </div>
-                                                )}
-                                            </form>
-                                        </div>
-                                    )
-                                }
-                            </div>
-                        )
-                    }
-                    <PaperSidebar
-                        rightSideFunction={rightSideFunction}
-                        setRightSideFunction={setRightSideFunction}
-                        PaperToolset={PaperToolset}
-                    />
+                                                    <form onSubmit={handleSubmit} className="flex flex-col gap-2" ref={chatInputFormRef}>
+                                                        {
+                                                            userMessageReferences.length > 0 && (
+                                                                <div className='flex flex-row gap-2'>
+                                                                    {userMessageReferences.map((ref, index) => (
+                                                                        <div key={index} className="text-xs text-secondary-foreground flex bg-secondary p-2 rounded-lg">
+                                                                            <p
+                                                                                className='
+                                                                overflow-hidden
+                                                                text-ellipsis
+                                                                whitespace-normal
+                                                                max-w-[200px]
+                                                                text-secondary-foreground
+                                                                line-clamp-2
+                                                                '
+                                                                                onClick={() =>
+                                                                                    setExplicitSearchTerm(ref)
+                                                                                }
+                                                                            >
+                                                                                {ref}
+                                                                            </p>
+                                                                            <Button
+                                                                                variant='ghost'
+                                                                                className='h-auto w-fit p-0 !px-0'
+                                                                                onClick={() =>
+                                                                                    setUserMessageReferences(prev => prev.filter((_, i) => i !== index))
+                                                                                }
+                                                                            >
+                                                                                <X size={2} />
+                                                                            </Button>
+                                                                        </div>
+                                                                    ))}
+                                                                </div>
+                                                            )
+                                                        }
+                                                        <div
+                                                            className='rounded-md p-0.5 flex flex-col gap-2 bg-secondary'
+                                                        >
+                                                            {/* User message input area */}
+                                                            <Textarea
+                                                                value={currentMessage}
+                                                                onChange={handleTextareaChange}
+                                                                ref={inputMessageRef}
+                                                                placeholder="Ask something about this paper."
+                                                                className="border-none bg-secondary dark:bg-secondary rounded-md resize-none hover:resize-y p-2 focus-visible:outline-none focus-visible:ring-0 shadow-none min-h-[2rem] max-h-32"
+                                                                disabled={isStreaming || (creditUsage?.usagePercentage ?? 0) >= 100}
+                                                                onKeyDown={(e) => {
+                                                                    if (e.key === 'Enter' && !e.shiftKey) {
+                                                                        e.preventDefault();
+                                                                        handleSubmit(e);
+                                                                    }
+                                                                }}
+                                                            />
+                                                            <div className="flex flex-row justify-between gap-2">
+                                                                <div className="flex flex-row gap-2">
+                                                                    <DropdownMenu>
+                                                                        <DropdownMenuTrigger asChild>
+                                                                            <Button
+                                                                                variant="ghost"
+                                                                                className="w-fit text-sm"
+                                                                                title='Settings - Configure model and response style'
+                                                                                disabled={isStreaming}
+                                                                            >
+                                                                                <Route
+                                                                                    className="h-4 w-4 text-secondary-foreground"
+                                                                                />
+                                                                            </Button>
+                                                                        </DropdownMenuTrigger>
+                                                                        <DropdownMenuContent className="w-56">
+                                                                            <DropdownMenuSub>
+                                                                                <DropdownMenuSubTrigger className="flex items-center">
+                                                                                    <Sparkle className="mr-2 h-4 w-4" />
+                                                                                    <span>Model {selectedModel ? `(${availableModels[selectedModel]})` : ''}</span>
+                                                                                </DropdownMenuSubTrigger>
+                                                                                <DropdownMenuSubContent>
+                                                                                    {Object.entries(availableModels).map(([key, value]) => (
+                                                                                        <DropdownMenuItem
+                                                                                            key={key}
+                                                                                            onClick={() => setSelectedModel(key)}
+                                                                                            className="flex items-center justify-between"
+                                                                                        >
+                                                                                            <span>{value}</span>
+                                                                                            {selectedModel === key && (
+                                                                                                <Check className="h-4 w-4 text-green-500" />
+                                                                                            )}
+                                                                                        </DropdownMenuItem>
+                                                                                    ))}
+                                                                                </DropdownMenuSubContent>
+                                                                            </DropdownMenuSub>
+
+                                                                            <DropdownMenuSub>
+                                                                                <DropdownMenuSubTrigger className="flex items-center">
+                                                                                    <Feather className="mr-2 h-4 w-4" />
+                                                                                    <span>Response Style {responseStyle ? `(${responseStyle})` : ''}</span>
+                                                                                </DropdownMenuSubTrigger>
+                                                                                <DropdownMenuSubContent>
+                                                                                    {Object.values(ResponseStyle).map((style) => (
+                                                                                        <DropdownMenuItem
+                                                                                            key={style}
+                                                                                            onClick={() => {
+                                                                                                setResponseStyle(style);
+                                                                                                setRightSideFunction('Chat');
+                                                                                            }}
+                                                                                            className="flex items-center justify-between"
+                                                                                        >
+                                                                                            <span>{style}</span>
+                                                                                            {style === responseStyle && (
+                                                                                                <Check className="h-4 w-4 text-green-500" />
+                                                                                            )}
+                                                                                        </DropdownMenuItem>
+                                                                                    ))}
+                                                                                </DropdownMenuSubContent>
+                                                                            </DropdownMenuSub>
+                                                                        </DropdownMenuContent>
+                                                                    </DropdownMenu>
+                                                                </div>
+                                                                <Button
+                                                                    type="submit"
+                                                                    onKeyDown={(e) => {
+                                                                        if (e.key === 'Enter' && !e.shiftKey) {
+                                                                            e.preventDefault();
+                                                                            handleSubmit(e);
+                                                                        }
+                                                                    }}
+                                                                    variant="default"
+                                                                    className="w-fit rounded-full h-fit !px-2 py-2 bg-blue-500 hover:bg-blue-400"
+                                                                    disabled={isStreaming}
+                                                                >
+                                                                    <ArrowUp
+                                                                        className="h-4 w-4 rounded-full"
+                                                                        aria-hidden="true"
+                                                                    />
+                                                                </Button>
+                                                            </div>
+                                                        </div>
+                                                        {/* Chat Credit Usage Display */}
+                                                        {creditUsage && creditUsage.showWarning && (
+                                                            <div className={`text-xs px-2 py-1 ${creditUsage.isCritical ? 'text-red-600 dark:text-red-400' : 'text-amber-600 dark:text-amber-400'} justify-between flex`}>
+                                                                <div className="font-semibold">{creditUsage.used} credits used</div>
+                                                                <div className="font-semibold">
+                                                                    <HoverCard>
+                                                                        <HoverCardTrigger asChild>
+                                                                            <span>{creditUsage.remaining} credits remaining</span>
+                                                                        </HoverCardTrigger>
+                                                                        <HoverCardContent side="top" className="w-48">
+                                                                            <p className="text-sm">Resets on {nextMonday.toLocaleDateString()}</p>
+                                                                        </HoverCardContent>
+                                                                    </HoverCard>
+                                                                    <Link
+                                                                        href="/pricing"
+                                                                        className="text-blue-500 hover:text-blue-700 ml-1"
+                                                                    >
+                                                                        Upgrade
+                                                                    </Link>
+                                                                </div>
+                                                            </div>
+                                                        )}
+                                                    </form>
+                                                </div>
+                                            )
+                                        }
+                                    </div>
+                                )
+                            }
+                            <PaperSidebar
+                                rightSideFunction={rightSideFunction}
+                                setRightSideFunction={setRightSideFunction}
+                                PaperToolset={PaperToolset}
+                            />
+                        </>
+                    )}
                 </div>
             </div >
         </div >

--- a/client/src/components/hooks/PdfAnnotation.ts
+++ b/client/src/components/hooks/PdfAnnotation.ts
@@ -68,7 +68,7 @@ export function useAnnotations(paperId: string) {
         }
     };
 
-    const loadAnnotationsFromServer = async () => {
+    const fetchAnnotations = async () => {
         try {
             const loadedAnnotations: PaperHighlightAnnotation[] = await fetchFromApi(`/api/annotation/${paperId}`, {
                 method: 'GET',
@@ -80,6 +80,10 @@ export function useAnnotations(paperId: string) {
             console.error('Error loading annotations:', error);
             throw error;
         }
+    };
+
+    const refreshAnnotations = async () => {
+        await fetchAnnotations();
     };
 
     const renderAnnotations = (highlights: PaperHighlightAnnotation[]) => {
@@ -110,7 +114,7 @@ export function useAnnotations(paperId: string) {
     };
 
     useEffect(() => {
-        loadAnnotationsFromServer();
+        fetchAnnotations();
     }, []);
 
     return {
@@ -119,7 +123,8 @@ export function useAnnotations(paperId: string) {
         addAnnotation,
         removeAnnotation,
         updateAnnotation,
-        loadAnnotationsFromServer,
+        fetchAnnotations,
+        refreshAnnotations,
         getAnnotationsForHighlight,
         renderAnnotations,
     };

--- a/client/src/components/hooks/PdfHighlight.ts
+++ b/client/src/components/hooks/PdfHighlight.ts
@@ -58,7 +58,7 @@ export function useHighlights(paperId: string, readOnlyHighlights: Array<PaperHi
             setHighlights(readOnlyHighlights);
         }
         else {
-            loadHighlights();
+            fetchHighlights();
         }
     }, []);
 
@@ -253,14 +253,14 @@ export function useHighlights(paperId: string, readOnlyHighlights: Array<PaperHi
             const updatedHighlights = highlights.filter(h => h.id !== highlight.id);
             setHighlights(updatedHighlights);
             clearHighlightsFromDOM();
-            loadHighlights();
-        }
+            fetchHighlights();
+    }
         catch (error) {
             console.error('Error removing highlight from server:', error);
         }
     }
 
-    const loadHighlights = async () => {
+    const fetchHighlights = async () => {
         try {
             const data: PaperHighlight[] = await fetchFromApi(`/api/highlight/${paperId}`, {
                 method: 'GET',
@@ -292,6 +292,10 @@ export function useHighlights(paperId: string, readOnlyHighlights: Array<PaperHi
             console.error('Error loading highlights from server:', error);
         }
     }
+
+    const refreshHighlights = async () => {
+        await fetchHighlights();
+    };
 
     // Helper function to normalize selected text
     const normalizeSelectedText = (text: string): string => {
@@ -375,6 +379,7 @@ export function useHighlights(paperId: string, readOnlyHighlights: Array<PaperHi
         clearHighlights,
         addHighlight,
         removeHighlight,
-        loadHighlights,
+        fetchHighlights,
+        refreshHighlights,
     };
 }

--- a/client/src/lib/schema.ts
+++ b/client/src/lib/schema.ts
@@ -206,3 +206,14 @@ export interface PaperImage {
     image_index: number;
     caption: string | null;
 }
+
+export interface JobStatusResponse {
+	job_id: string;
+	status: JobStatusType;
+	started_at: string;
+	completed_at: string | null;
+	paper_id: string | null;
+	has_file_url: boolean;
+	has_metadata: boolean;
+	celery_progress_message: string | null;
+}

--- a/jobs/src/tasks.py
+++ b/jobs/src/tasks.py
@@ -140,18 +140,22 @@ async def process_pdf_file(
                 return None, None
 
         async def extract_images_async():
-            status_callback("Extracting images from PDF")
-            logger.info(f"About to call extract_images_from_pdf for job {job_id}")
-            try:
-                result = await extract_captions_for_images(
-                    images=extracted_images,
-                    file_path=temp_file_path,
-                    image_id_to_location=placeholder_to_path,
-                )
-                logger.info(f"extract_images_from_pdf returned {len(result) if result else 0} images")
-                return result
-            except Exception as e:
-                logger.error(f"Failed to extract images from {safe_filename}: {str(e)}", exc_info=True)
+            if extract_images:
+                status_callback("Extracting images from PDF")
+                logger.info(f"About to call extract_images_from_pdf for job {job_id}")
+                try:
+                    result = await extract_captions_for_images(
+                        images=extracted_images,
+                        file_path=temp_file_path,
+                        image_id_to_location=placeholder_to_path,
+                    )
+                    logger.info(f"extract_images_from_pdf returned {len(result) if result else 0} images")
+                    return result
+                except Exception as e:
+                    logger.error(f"Failed to extract images from {safe_filename}: {str(e)}", exc_info=True)
+                    return []
+            else:
+                logger.info(f"Image extraction skipped for {safe_filename}")
                 return []
 
         # Run I/O-bound tasks and LLM extraction concurrently

--- a/server/app/api/paper_upload_api.py
+++ b/server/app/api/paper_upload_api.py
@@ -30,6 +30,7 @@ from app.database.database import get_db
 from app.database.models import PaperUploadJob
 from app.database.telemetry import track_event
 from app.helpers.pdf_jobs import pdf_jobs_client
+from app.helpers.s3 import s3_service
 from app.helpers.subscription_limits import (
     can_user_access_knowledge_base,
     can_user_upload_paper,
@@ -273,7 +274,10 @@ async def upload_file_from_url_microservice(
 
         # Submit to microservice
         task_id = await pdf_jobs_client.submit_pdf_processing_job_with_upload(
-            pdf_bytes=file_contents, job_id=str(paper_upload_job.id)
+            pdf_bytes=file_contents,
+            paper_upload_job=paper_upload_job,
+            db=db,
+            user=current_user,
         )
 
         # Update job with task_id
@@ -342,7 +346,10 @@ async def upload_raw_file_microservice(
     try:
         # Submit to microservice
         task_id = await pdf_jobs_client.submit_pdf_processing_job_with_upload(
-            pdf_bytes=file_contents, job_id=str(paper_upload_job.id)
+            pdf_bytes=file_contents,
+            paper_upload_job=paper_upload_job,
+            db=db,
+            user=current_user,
         )
 
         # Update job with task_id

--- a/server/app/api/webhook_api.py
+++ b/server/app/api/webhook_api.py
@@ -7,7 +7,7 @@ import uuid
 from datetime import datetime, timezone
 from typing import List, Optional
 
-from app.database.crud.paper_crud import PaperCreate, paper_crud
+from app.database.crud.paper_crud import PaperCreate, PaperUpdate, paper_crud
 from app.database.crud.paper_image_crud import PaperImageCreate, paper_image_crud
 from app.database.crud.paper_upload_crud import paper_upload_job_crud
 from app.database.database import get_db
@@ -135,12 +135,14 @@ async def handle_paper_processing_webhook(
 
             publish_date = metadata.publish_date if metadata.publish_date else None
 
+            existing_paper = paper_crud.get_by_upload_job_id(
+                db=db, upload_job_id=job_id, user=job_user
+            )
+
             # Create paper record
-            paper = paper_crud.create(
+            paper = paper_crud.update(
                 db=db,
-                obj_in=PaperCreate(
-                    file_url=file_url,
-                    s3_object_key=result.s3_object_key,
+                obj_in=PaperUpdate(
                     upload_job_id=job_id,
                     preview_url=preview_url,
                     title=metadata.title,
@@ -156,6 +158,7 @@ async def handle_paper_processing_webhook(
                     page_offset_map=result.page_offset_map,
                     size_in_kb=size_in_kb,
                 ),
+                db_obj=existing_paper,
                 user=job_user,
             )
 

--- a/server/app/database/crud/paper_crud.py
+++ b/server/app/database/crud/paper_crud.py
@@ -50,7 +50,7 @@ class PaperBase(BaseModel):
 class PaperCreate(PaperBase):
     # Only mandate required fields for creation, others are optional
     file_url: str  # type: ignore
-    raw_content: str  # type: ignore
+    raw_content: Optional[str] = None  # type: ignore
     s3_object_key: Optional[str] = None
     upload_job_id: Optional[str] = None
     preview_url: Optional[str] = None
@@ -60,6 +60,8 @@ class PaperUpdate(PaperBase):
     status: Optional[PaperStatus] = PaperStatus.todo
     cached_presigned_url: Optional[str] = None
     presigned_url_expires_at: Optional[datetime] = None
+    preview_url: Optional[str] = None
+    raw_content: Optional[str] = None
     open_alex_id: Optional[str] = None
     doi: Optional[str] = None
     size_in_kb: Optional[int] = None


### PR DESCRIPTION
File processing latency can still be between 45s-360s. To mitigate some of this wait time, automatically redirect to the paper viewing page, where the article can be displayed while metadata extraction is being completed. This helps you quickly get to a state where you can start reading the paper, even if all of the background data isn't available yet.

We do this by immediately creating the Paper object on the backend, before the data packet is sent off to the jobs service for processing. That file_url is populated, allowing the front-end to quickly redirect to the rich reading experience. 

When the webhook data is returned, we do an `update`, rather than a `create`, since the paper object already exists.