### PR TITLE
improve narrative generation via gemini flash

### DIFF
--- a/server/app/llm/paper_operations.py
+++ b/server/app/llm/paper_operations.py
@@ -18,7 +18,7 @@ from app.llm.prompts import (
     NORMAL_MODE_INSTRUCTIONS,
 )
 from app.llm.provider import FileContent, LLMProvider, TextContent
-from app.llm.utils import retry_llm_operation
+from app.llm.utils import LLMBlockedError, retry_llm_operation
 from app.schemas.message import ResponseStyle
 from app.schemas.responses import AudioOverviewForLLM
 from app.schemas.user import CurrentUser
@@ -95,10 +95,27 @@ class PaperOperations(BaseLLMClient):
         ]
 
         # Generate narrative summary using the LLM
-        response = self.generate_content(
-            contents=message_content,
-            schema=AudioOverviewForLLM,
-        )
+        try:
+            response = self.generate_content(
+                contents=message_content,
+                schema=AudioOverviewForLLM,
+            )
+        except LLMBlockedError as e:
+            # Narrating a whole paper is the longest single generation we ask
+            # for, which makes it the most likely to wander into a stretch the
+            # model has memorized and trip Gemini's recitation filter. That
+            # verdict is a property of the sampled continuation, not of the
+            # request, so one fresh draw usually clears it — unlike a safety or
+            # blocklist verdict, which is stable and gets re-raised as-is.
+            if not e.is_recitation:
+                raise
+            logger.warning(
+                f"Recitation block on narrative summary for paper {paper_id}; resampling once."
+            )
+            response = self.generate_content(
+                contents=message_content,
+                schema=AudioOverviewForLLM,
+            )
 
         try:
             if response and response.text:

--- a/server/app/llm/prompts.py
+++ b/server/app/llm/prompts.py
@@ -9,7 +9,7 @@ Your summary should be approximately {length} words long (this is important - ai
 
 Write the summary in plain text, with minimal syntax formatting for citations.
 
-Include any citations or references to specific sections of the paper, reproducing the raw text. It should read like a cohesive brief that could be read on a podcast or in a blog post.
+Cite the specific sections of the paper that back your claims, but narrate them in your own words. This summary is going to be read aloud, so do not reproduce long passages of the paper verbatim in it. It should read like a cohesive brief that could be read on a podcast or in a blog post.
 
 Citations should be formatted as [^1], [^2], etc., where each number corresponds to the idx of the list of citations you will provide at the end of the summary.
 

--- a/server/app/llm/provider.py
+++ b/server/app/llm/provider.py
@@ -374,7 +374,10 @@ class GeminiProvider(BaseLLMProvider):
         )
 
         if finish_reason in BLOCKED_REASONS:
-            raise LLMBlockedError(f"Gemini declined to answer ({model}): {detail}")
+            raise LLMBlockedError(
+                f"Gemini declined to answer ({model}): {detail}",
+                reason=getattr(finish_reason, "name", str(finish_reason)),
+            )
 
         # MAX_TOKENS, OTHER, or STOP-with-empty-text fall through as retryable —
         # but the message now tells us which one so we can act on it.

--- a/server/app/llm/utils.py
+++ b/server/app/llm/utils.py
@@ -16,7 +16,21 @@ logger = logging.getLogger(__name__)
 
 class LLMBlockedError(Exception):
     """The model declined to produce output for a reason that retrying won't fix
-    (safety filter, recitation, prompt-level block, malformed function call)."""
+    (safety filter, recitation, prompt-level block, malformed function call).
+
+    `reason` is the provider's finish reason as a bare name (e.g. "RECITATION"),
+    so callers can tell the terminal blocks apart from the one that isn't:
+    recitation depends on the sampled continuation, not on anything stable about
+    the request.
+    """
+
+    def __init__(self, message: str, reason: str | None = None):
+        super().__init__(message)
+        self.reason = reason
+
+    @property
+    def is_recitation(self) -> bool:
+        return self.reason == "RECITATION"
 
 
 # Exceptions that should trigger a retry with backoff. LLMBlockedError is

--- a/server/app/tasks/audio_overview.py
+++ b/server/app/tasks/audio_overview.py
@@ -247,7 +247,10 @@ async def generate_audio_overview(
                 job_id=audio_overview_job_id,
                 status=JobStatus.FAILED,
                 current_user=user,
-                status_message=f"Failed: {str(e)[:200]}",
+                # The exception text carries provider diagnostics (finish
+                # reasons, model ids) that render verbatim in the job card;
+                # the traceback above is where they belong.
+                status_message="Failed to generate audio overview. Please try again.",
             )
             track_event(
                 "audio_overview_failed",

--- a/server/tests/test_recitation_retry.py
+++ b/server/tests/test_recitation_retry.py
@@ -1,0 +1,144 @@
+"""What happens when Gemini refuses to narrate a paper it has memorized.
+
+Narrating a whole paper is the longest single generation this app asks for, and
+it runs against a published PDF — the exact conditions under which Gemini's
+recitation filter kills the candidate and returns nothing at all.
+
+Recitation is the one block reason that is not a property of the request. Safety
+and blocklist verdicts are stable: the same prompt earns the same refusal, and
+re-asking only burns tokens. Recitation depends on the continuation that got
+sampled, so a second draw usually lands somewhere else and succeeds. These tests
+hold that distinction — recitation is resampled exactly once, everything else
+still surfaces immediately.
+"""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from app.llm.paper_operations import PaperOperations
+from app.llm.provider import GeminiProvider
+from app.llm.utils import LLMBlockedError
+from google.genai.types import FinishReason
+
+SUMMARY_JSON = '{"summary": "A paper, narrated.", "citations": [], "title": "Overview"}'
+
+
+def blocked_response(finish_reason) -> SimpleNamespace:
+    """A candidate the filter emptied: a finish reason and no parts."""
+    return SimpleNamespace(
+        prompt_feedback=None,
+        candidates=[
+            SimpleNamespace(
+                finish_reason=finish_reason,
+                content=SimpleNamespace(parts=[]),
+            )
+        ],
+    )
+
+
+class BlockReasonTaggingTest(unittest.TestCase):
+    def raise_for(self, finish_reason) -> LLMBlockedError:
+        with self.assertRaises(LLMBlockedError) as caught:
+            GeminiProvider._raise_for_empty_response(
+                blocked_response(finish_reason), "gemini-3.6-flash"
+            )
+        return caught.exception
+
+    def test_recitation_is_tagged_so_callers_can_single_it_out(self):
+        error = self.raise_for(FinishReason.RECITATION)
+
+        self.assertEqual(error.reason, "RECITATION")
+        self.assertTrue(error.is_recitation)
+
+    def test_safety_is_tagged_but_is_not_recitation(self):
+        error = self.raise_for(FinishReason.SAFETY)
+
+        self.assertEqual(error.reason, "SAFETY")
+        self.assertFalse(error.is_recitation)
+
+
+class NarrativeSummaryRecitationTest(unittest.TestCase):
+    """Drive create_narrative_summary with everything but the model stubbed out."""
+
+    def setUp(self):
+        # __init__ builds live provider clients from API keys; the seam under
+        # test is below that, so skip it.
+        self.operations = PaperOperations.__new__(PaperOperations)
+        self.calls = 0
+
+        paper = SimpleNamespace(
+            id="paper-1",
+            title="A Paper",
+            s3_object_key="key",
+            raw_content=None,
+        )
+        patches = [
+            patch(
+                "app.llm.paper_operations.paper_crud",
+                SimpleNamespace(get=lambda *a, **k: paper),
+            ),
+            patch(
+                "app.llm.paper_operations.s3_service",
+                SimpleNamespace(get_cached_presigned_url=lambda *a, **k: "https://pdf"),
+            ),
+            patch(
+                "app.llm.paper_operations.httpx.get",
+                lambda *a, **k: SimpleNamespace(content=b"%PDF-1.4"),
+            ),
+        ]
+        for p in patches:
+            p.start()
+            self.addCleanup(p.stop)
+
+    def summarize(self):
+        return self.operations.create_narrative_summary(
+            paper_id="paper-1", user=SimpleNamespace(id="user-1"), db=SimpleNamespace()
+        )
+
+    def script(self, first: LLMBlockedError):
+        """A generate_content that raises `first`, then answers."""
+
+        def generate_content(**kwargs):
+            self.calls += 1
+            if self.calls == 1:
+                raise first
+            return SimpleNamespace(text=SUMMARY_JSON)
+
+        return generate_content
+
+    def test_recitation_is_resampled_once_and_the_second_draft_is_returned(self):
+        self.operations.generate_content = self.script(
+            LLMBlockedError("recited", reason="RECITATION")
+        )
+
+        summary = self.summarize()
+
+        self.assertEqual(self.calls, 2)
+        self.assertEqual(summary.summary, "A paper, narrated.")
+
+    def test_a_stable_block_is_not_resampled(self):
+        self.operations.generate_content = self.script(
+            LLMBlockedError("unsafe", reason="SAFETY")
+        )
+
+        with self.assertRaises(LLMBlockedError):
+            self.summarize()
+
+        self.assertEqual(self.calls, 1)
+
+    def test_a_second_recitation_gives_up_rather_than_looping(self):
+        def always_recites(**kwargs):
+            self.calls += 1
+            raise LLMBlockedError("recited", reason="RECITATION")
+
+        self.operations.generate_content = always_recites
+
+        with self.assertRaises(LLMBlockedError):
+            self.summarize()
+
+        self.assertEqual(self.calls, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
currently hitting occasional recitation errors, meaning that the API flagged a verbatim match from existing pretraining data. to mitigate this, 1. tell the model that it can use a summarizing approach for the core narration and 2. add a retry if/when a recitation reason is encountered for a blocked generation.