### PR TITLE
Fix project answer issues

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -116,7 +116,7 @@ anyone's local database.
 | `seed` | Force-restore the fixture over a dirty database |
 | `build-fixture` | Re-ingest the seed PDFs and refreeze the fixture (rare) |
 | `migrate` | Run alembic migrations |
-| `restart server` | Pick up server edits (no autoreload; client hot-reloads) |
+| `restart server` | Restart the API (it autoreloads on `server/app` edits, so this is only for env or dependency changes) |
 | `rebuild <svc>` | After a `yarn.lock` or `uv.lock` change |
 
 ### The fixture

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -107,8 +107,7 @@ services:
     build:
       context: ./server
     # python -m app.main runs uvicorn directly (readable single-process logs),
-    # where prod runs gunicorn. There is no autoreload: after editing server
-    # code, `scripts/dev restart server`.
+    # where prod runs gunicorn.
     command: ["python3", "-m", "app.main"]
     env_file: [server/.env]
     environment:
@@ -140,6 +139,18 @@ services:
       ZOTERO_REDIRECT_URI: http://${DEV_HOST:-127.0.0.1}:${SERVER_PORT:-8100}/api/auth/zotero/callback
       LANGFUSE_TRACING_ENVIRONMENT: local-docker
       DEBUG: "True"
+      # Autoreload. server/ is bind-mounted, so edits are live in the container
+      # immediately — but the uvicorn process keeps whatever it imported at
+      # start. Without this, anything exercised through the HTTP API runs stale
+      # code until `scripts/dev restart server`, while `scripts/dev exec` spawns
+      # a fresh process and looks perfectly fine. That asymmetry is a
+      # verification trap, not a convenience problem: an agent can watch tests
+      # pass against code the running app is not serving.
+      #
+      # It works over the bind mount only because watchfiles is not installed,
+      # so uvicorn falls back to StatReload and polls mtimes. inotify events do
+      # not cross a macOS bind mount, so the faster watcher would see nothing.
+      UVICORN_RELOAD: "True"
     ports:
       - "${SERVER_PORT:-8100}:8000"
     volumes:

--- a/server/app/api/message_api.py
+++ b/server/app/api/message_api.py
@@ -43,6 +43,11 @@ message_router = APIRouter()
 
 END_DELIMITER = "END_OF_STREAM"
 
+ANSWER_FAILED_MESSAGE = (
+    "I ran into a problem writing this response. Please try asking again — if it "
+    "keeps happening, contact support (saba@openpaper.ai)."
+)
+
 
 def _append_status(messages: Optional[List[str]], message: str) -> None:
     """Append a status message, collapsing consecutive duplicates (e.g. heartbeats)."""
@@ -58,8 +63,14 @@ async def _stream_chat_chunks(
     evidence_container: dict,
     artifacts: Optional[List] = None,
     status_messages: Optional[List[str]] = None,
+    errors: Optional[List[str]] = None,
 ) -> AsyncGenerator[str, None]:
-    """Helper to stream chat chunks and handle common logic."""
+    """Helper to stream chat chunks and handle common logic.
+
+    Anything appended to `errors` has already been reported to the client, so
+    the caller can tell a turn that failed loudly from one that simply ended
+    with nothing to show.
+    """
     async for chunk in chunk_generator:
         if not isinstance(chunk, dict):
             logger.warning(f"Received unexpected chunk format: {chunk}")
@@ -119,6 +130,15 @@ async def _stream_chat_chunks(
         elif chunk_type == "status":
             _append_status(status_messages, chunk_content)
             yield f"{json.dumps({'type': 'status', 'content': chunk_content})}{END_DELIMITER}"
+        elif chunk_type == "error":
+            # The answer stream failed. Forwarding this is what turns a blank
+            # message into something the user can act on — the client renders
+            # it and stops the turn. Dropping it here left the two
+            # indistinguishable.
+            logger.error(f"Error while streaming the answer: {chunk_content}")
+            if errors is not None:
+                errors.append(str(chunk_content))
+            yield f"{json.dumps({'type': 'error', 'content': chunk_content})}{END_DELIMITER}"
 
 
 @message_router.get("/models")
@@ -277,6 +297,7 @@ async def chat_message_multipaper(
                 content_chunks = []
                 artifacts_collected: List[dict] = []
                 status_messages: List[str] = []
+                stream_errors: List[str] = []
                 start_time = datetime.now(timezone.utc)
                 evidence_container = {"evidence": None}
                 evidence_collection: Optional[EvidenceCollection] = None
@@ -412,6 +433,8 @@ async def chat_message_multipaper(
                     current_user=current_user,
                     all_papers=all_papers,
                     mentioned_highlights=mentioned_highlights,
+                    project_title=str(project.title) if request.project_id else None,
+                    is_mention_scoped=scoped_paper_ids is not None,
                     db=db,
                 )
                 async for stream_chunk in _stream_chat_chunks(
@@ -420,6 +443,7 @@ async def chat_message_multipaper(
                     evidence_container=evidence_container,
                     artifacts=artifacts_collected,
                     status_messages=status_messages,
+                    errors=stream_errors,
                 ):
                     yield stream_chunk
 
@@ -427,6 +451,37 @@ async def chat_message_multipaper(
 
                 # Save the complete message to the database
                 full_content = "".join(content_chunks)
+
+                # An answer that produced no text is a failure, not a turn.
+                # Persisting it puts a blank bubble in the thread and — worse —
+                # replays an empty model part into the history of every later
+                # turn in this conversation, which visibly degrades them. Say
+                # what happened instead and leave the thread as it was.
+                if not full_content.strip() and not artifacts_collected:
+                    logger.error(
+                        "Answer stream produced no content for conversation %s; "
+                        "not saving an empty turn.",
+                        request.conversation_id,
+                    )
+                    # Counted as well as logged. This failure used to be
+                    # invisible from every direction — nothing raised, the
+                    # request returned 200, and the only trace was a blank row
+                    # that looked like a real message. A metric is what makes a
+                    # regression here noticeable before a user reports it.
+                    track_event(
+                        "chat_answer_empty",
+                        properties={
+                            "had_stream_error": bool(stream_errors),
+                            "has_evidence": bool(evidence),
+                            "type": conversation.conversable_type,
+                            "project_id": request.project_id,
+                        },
+                        user_id=str(current_user.id),
+                        db=db,
+                    )
+                    if not stream_errors:
+                        yield f"{json.dumps({'type': 'error', 'content': ANSWER_FAILED_MESSAGE})}{END_DELIMITER}"
+                    return
 
                 assistant_trace = (
                     evidence_collection.to_trace_dict() if evidence_collection else None
@@ -628,6 +683,7 @@ async def chat_message_stream(
         async def response_generator():
             try:
                 content_chunks = []
+                stream_errors: List[str] = []
                 start_time = datetime.now(timezone.utc)
                 evidence_container = {"evidence": None}
 
@@ -646,6 +702,7 @@ async def chat_message_stream(
                     chunk_generator=chat_generator,
                     content_chunks=content_chunks,
                     evidence_container=evidence_container,
+                    errors=stream_errors,
                 ):
                     yield chunk
 
@@ -653,6 +710,31 @@ async def chat_message_stream(
 
                 # Save the complete message to the database
                 full_content = "".join(content_chunks)
+
+                # An answer that produced no text is a failure, not a turn.
+                # Persisting it puts a blank bubble in the thread and — worse —
+                # replays an empty model part into the history of every later
+                # turn in this conversation, which visibly degrades them. Say
+                # what happened instead and leave the thread as it was.
+                if not full_content.strip():
+                    logger.error(
+                        "Answer stream produced no content for conversation %s; "
+                        "not saving an empty turn.",
+                        request.conversation_id,
+                    )
+                    track_event(
+                        "chat_answer_empty",
+                        properties={
+                            "had_stream_error": bool(stream_errors),
+                            "has_evidence": bool(evidence),
+                            "type": "paper",
+                        },
+                        user_id=str(current_user.id),
+                        db=db,
+                    )
+                    if not stream_errors:
+                        yield f"{json.dumps({'type': 'error', 'content': ANSWER_FAILED_MESSAGE})}{END_DELIMITER}"
+                    return
 
                 formatted_references = (
                     CitationHandler.convert_references_to_dict(

--- a/server/app/database/crud/paper_crud.py
+++ b/server/app/database/crud/paper_crud.py
@@ -641,16 +641,25 @@ class PaperCRUD(CRUDBase["Paper", PaperCreate, PaperUpdate]):
             FROM paper_passages pp
             JOIN papers p ON p.id = pp.paper_id
             WHERE pp.ts_vector @@ ({fts_query_clause})
-              AND p.user_id = :user_id
         """
 
-        params: dict = {"user_id": user.id}
+        params: dict = {}
         for i, term in enumerate(search_terms):
             params[f"term_{i}"] = term
 
         if paper_ids:
+            # An explicit paper set has already been authorized by the caller —
+            # project membership, or a resolved @-mention scope — and those
+            # papers are not necessarily the caller's own. Narrowing again by
+            # owner is what made this search return nothing on a shared
+            # project while every other tool read the same papers fine.
             sql += " AND pp.paper_id = ANY(:paper_ids)"
             params["paper_ids"] = paper_ids
+        else:
+            # No explicit set: the search is over the whole library, and
+            # ownership is the only thing scoping it.
+            sql += " AND p.user_id = :user_id"
+            params["user_id"] = user.id
 
         sql += " ORDER BY pp.paper_id, pp.start_line"
 

--- a/server/app/llm/evidence_operations.py
+++ b/server/app/llm/evidence_operations.py
@@ -28,6 +28,7 @@ from app.llm.prompts import (
     EVIDENCE_GATHERING_SYSTEM_PROMPT,
     KEYWORD_EXTRACTION_PROMPT,
     TOOL_RESULT_COMPACTION_PROMPT,
+    format_scope,
 )
 from app.llm.provider import LLMProvider, TextContent
 from app.llm.tools.file_tools import (
@@ -71,6 +72,11 @@ HEARTBEAT_INTERVAL_SECONDS = (
 )
 
 _tool_executor = ThreadPoolExecutor(max_workers=4)
+
+# How many papers the abstract fallback will read. Generous enough to cover a
+# normal project whole, bounded so a large library cannot blow the answer
+# model's context on a question that already failed to retrieve anything.
+ABSTRACT_FALLBACK_PAPER_LIMIT = 30
 
 # Structured-output schema for the fallback keyword extractor — provider
 # constrains the response to this shape so we never have to scrape JSON out of
@@ -152,7 +158,7 @@ class EvidenceOperations(BaseLLMClient):
         n_iterations = 0
         max_iterations = 4
 
-        project_title = "Project"
+        project_title: Optional[str] = None
         if project_id:
             project = project_crud.get(db, id=project_id, user=current_user)
             if not project:
@@ -174,6 +180,15 @@ class EvidenceOperations(BaseLLMClient):
         if restrict_to_paper_ids is not None:
             allowed_ids = set(restrict_to_paper_ids)
             all_papers = [paper for paper in all_papers if str(paper.id) in allowed_ids]
+
+        # Both models in this turn are told the same thing about what set they
+        # hold, so the answer cannot describe a different container than the
+        # search covered.
+        scope = format_scope(
+            n_papers=len(all_papers),
+            project_title=project_title,
+            is_mention_scoped=restrict_to_paper_ids is not None,
+        )
 
         formatted_paper_options = {
             str(paper.id): {
@@ -252,6 +267,7 @@ class EvidenceOperations(BaseLLMClient):
                 )
 
             evidence_gathering_prompt = EVIDENCE_GATHERING_SYSTEM_PROMPT.format(
+                scope=scope,
                 available_papers=formatted_paper_options,
                 n_iteration=n_iterations,
                 max_iterations=max_iterations,
@@ -346,7 +362,7 @@ class EvidenceOperations(BaseLLMClient):
                         yield {
                             "type": "status",
                             "content": (
-                                f"Initiated chart creation for - {project_title}"
+                                f"Initiated chart creation for - {project_title or 'your library'}"
                                 if fn_name == "create_chart_artifact"
                                 else f"{pretty_fn_name} - {paper_name}{display_query}"
                             ),
@@ -524,6 +540,55 @@ class EvidenceOperations(BaseLLMClient):
                     user_id=str(current_user.id),
                     db=db,
                 )
+
+        # Last resort: the papers themselves.
+        #
+        # Everything above is retrieval — it finds passages by matching terms
+        # against them. That is the wrong shape for the question this whole
+        # feature exists to answer. "What are the key takeaways across these
+        # papers", "how do they differ" — there is no term to match, the search
+        # returns nothing, and the turn ends by telling the user their project
+        # has no relevant papers while their papers sit right there.
+        #
+        # So when search comes up empty on a question scoped to a known set of
+        # papers, hand over what the papers say about themselves. Abstracts are
+        # the papers' own text, not a summary this model invented, which keeps
+        # the answer grounded in the same way a retrieved passage is.
+        if (
+            not evidence_collection.has_evidence()
+            and not evidence_collection.get_artifacts()
+            and not evidence_collection.get_chart_jobs()
+            and all_papers
+        ):
+            logger.info(
+                "Search found nothing for %d in-scope paper(s); falling back to "
+                "their abstracts.",
+                len(all_papers),
+            )
+            yield {
+                "type": "status",
+                "content": "Reading the papers in scope...",
+            }
+
+            for paper in all_papers[:ABSTRACT_FALLBACK_PAPER_LIMIT]:
+                abstract = str(paper.abstract).strip() if paper.abstract else ""
+                if not abstract:
+                    continue
+                evidence_collection.add_evidence(
+                    str(paper.id),
+                    f"Abstract of '{paper.title}':\n\n{abstract}",
+                )
+
+            track_event(
+                "abstract_fallback",
+                {
+                    "papers_in_scope": len(all_papers),
+                    "papers_with_abstracts": len(evidence_collection.evidence),
+                    "project_type": project_id is not None,
+                },
+                user_id=str(current_user.id),
+                db=db,
+            )
 
         # Compact evidence if it exceeds the limit for chat response
         evidence_size = evidence_collection.get_evidence_size()

--- a/server/app/llm/multi_paper_operations.py
+++ b/server/app/llm/multi_paper_operations.py
@@ -19,6 +19,7 @@ from app.llm.prompts import (
     ANSWER_EVIDENCE_BASED_QUESTION_MESSAGE,
     ANSWER_EVIDENCE_BASED_QUESTION_SYSTEM_PROMPT,
     GENERATE_MULTI_PAPER_NARRATIVE_SUMMARY,
+    format_scope,
 )
 from app.llm.provider import LLMProvider, StreamChunk, SupplementaryContent, TextContent
 from app.llm.utils import retry_llm_operation
@@ -48,10 +49,17 @@ class MultiPaperOperations(EvidenceOperations):
         llm_provider: Optional[LLMProvider] = None,
         user_references: Optional[Sequence[str]] = None,
         mentioned_highlights: Optional[List[dict]] = None,
+        project_title: Optional[str] = None,
+        is_mention_scoped: bool = False,
         db: Session = Depends(get_db),
     ) -> AsyncGenerator[Union[str, dict], None]:
         """
         Chat with everything in the user's knowledge base using the specified model
+
+        `project_title` and `is_mention_scoped` describe the set of papers this
+        answer is being written about. They are the same inputs the gathering
+        loop was given, so the answer names the container the search actually
+        covered — a project by its title rather than "the library".
         """
         user_citations = (
             CitationHandler.convert_references_to_citations(user_references)
@@ -72,6 +80,11 @@ class MultiPaperOperations(EvidenceOperations):
         logger.debug(f"Evidence gathered: {evidence_gathered.get_evidence_dict()}")
 
         formatted_system_prompt = ANSWER_EVIDENCE_BASED_QUESTION_SYSTEM_PROMPT.format(
+            scope=format_scope(
+                n_papers=len(all_papers),
+                project_title=project_title,
+                is_mention_scoped=is_mention_scoped,
+            ),
             available_papers=formatted_paper_options,
         )
 

--- a/server/app/llm/prompts.py
+++ b/server/app/llm/prompts.py
@@ -126,8 +126,53 @@ You are in normal mode. Provide a balanced response to the user's question. Incl
 # ---------------------------------------------------------------------
 # Multi-paper operations related prompts
 # ---------------------------------------------------------------------
+# The two models in a turn — the one that gathers and the one that answers —
+# are given the same sentence about what they are looking at, so an answer
+# cannot describe a different container than the search covered.
+#
+# It matters because the user's own words are relative. "These papers", "this
+# project", "all of them" have no referent unless the model is told what set it
+# holds. CHART_SCOPE_SYSTEM_PROMPT has spelled this out for the chart agent for
+# a while; the chat loop used to say "the library" even inside a project.
+PROJECT_SCOPE = (
+    "The {n_papers} paper(s) listed below are everything this conversation "
+    'covers. The user has gathered them in a project they named "{project_title}". '
+    'Read an unqualified reference — "these papers", "this project", "all of '
+    'them", or no reference at all — as the whole set: never a subset, and never '
+    "their wider library."
+)
+
+LIBRARY_SCOPE = (
+    "The {n_papers} paper(s) listed below are everything this conversation "
+    "covers: the user's whole library. Read an unqualified reference — \"these "
+    'papers", "my papers", or no reference at all — as the whole set.'
+)
+
+MENTIONED_SCOPE = (
+    "The {n_papers} paper(s) listed below are everything this conversation "
+    "covers; the user narrowed it to them by name. Nothing outside the set is "
+    "available, and nothing outside it should be discussed."
+)
+
+
+def format_scope(
+    n_papers: int,
+    project_title: str | None = None,
+    is_mention_scoped: bool = False,
+) -> str:
+    """The one sentence both models get about what they are looking at."""
+    if is_mention_scoped:
+        return MENTIONED_SCOPE.format(n_papers=n_papers)
+    if project_title:
+        return PROJECT_SCOPE.format(project_title=project_title, n_papers=n_papers)
+    return LIBRARY_SCOPE.format(n_papers=n_papers)
+
+
 EVIDENCE_GATHERING_SYSTEM_PROMPT = """
 You are a systematic research assistant specializing in academic evidence synthesis. Your task is to strategically use the available tools to gather relevant evidence from academic papers to comprehensively answer user questions.
+
+## Scope
+{scope}
 
 ## Available Papers:
 {available_papers}
@@ -159,6 +204,8 @@ You are on iteration {n_iteration} of {max_iterations} allowed
 - `STOP`: Signal completion when you have gathered sufficient evidence
 
 **Tool Selection Guidelines:**
+- Let the size of the set above shape the plan. A handful of papers can each be read directly — reading every abstract is a reasonable opening move. A large one has to be narrowed by search first
+- A question about the set as a whole ("key takeaways", "how do these compare", "what should I understand") has no single term to search for. Cover the set rather than hunting for a phrase: read the abstracts, then follow the specifics each one raises
 - Start broad with `search_all_files` to identify which papers are relevant
 - Use `read_abstract` to quickly assess papers before diving deeper
 - Use `search_file` with well-crafted regex queries to find specific information
@@ -249,9 +296,17 @@ Return them in the `keywords` field of the JSON object.
 """
 
 ANSWER_EVIDENCE_BASED_QUESTION_SYSTEM_PROMPT = """
-You are an excellent researcher who provides precise, evidence-based answers from academic papers. Your responses must always include specific text evidence from the paper. You give holistic answers, not just snippets. Help the user understand the content across a library of papers. Your answers should be clear, concise, and informative.
+You are an excellent researcher who provides precise, evidence-based answers from academic papers. Your responses must always include specific text evidence from the paper. You give holistic answers, not just snippets. Help the user understand the content across a set of papers. Your answers should be clear, concise, and informative.
 
-These are the papers available in the library:
+## Scope
+{scope}
+
+Scope is context for reading the question, not a subject to write about. The user
+can see what they gave you, so do not open by naming the project, counting the
+papers, or announcing what the set is. Write as though the framing is understood
+and go straight to the substance.
+
+These are the papers in scope:
 {available_papers}
 
 You will receive collected evidence from a research assistant in a <collected_evidence> block within the user's message. This evidence has been gathered from the papers above. Use it to inform your answer to the user's question.

--- a/server/app/llm/provider.py
+++ b/server/app/llm/provider.py
@@ -11,7 +11,12 @@ import anthropic
 import openai
 from app.database.models import Message
 from app.llm.citation_handler import CitationHandler
-from app.llm.utils import STREAM_RESTART, LLMBlockedError, stream_with_retry
+from app.llm.utils import (
+    STREAM_RESTART,
+    EmptyStreamError,
+    LLMBlockedError,
+    stream_with_retry,
+)
 from app.schemas.responses import (
     FileContent,
     SupplementaryContent,
@@ -192,6 +197,20 @@ def _sanitize_schema_for_gemini(schema: Any) -> Any:
     return schema
 
 
+# Finish reasons where the model landed on a verdict rather than failing. Some
+# of them are stable properties of the request and re-asking only burns tokens;
+# the rest depend on which continuation got sampled. LLMBlockedError.reason
+# carries the distinction (see is_resamplable).
+BLOCKED_FINISH_REASONS = {
+    FinishReason.SAFETY,
+    FinishReason.RECITATION,
+    FinishReason.BLOCKLIST,
+    FinishReason.PROHIBITED_CONTENT,
+    FinishReason.SPII,
+    FinishReason.MALFORMED_FUNCTION_CALL,
+}
+
+
 class GeminiProvider(BaseLLMProvider):
     """Gemini LLM provider implementation"""
 
@@ -331,16 +350,6 @@ class GeminiProvider(BaseLLMProvider):
     def _raise_for_empty_response(
         response: Optional[GenerateContentResponse], model: str
     ) -> None:
-        # Non-retryable finish reasons: retrying won't change the outcome.
-        BLOCKED_REASONS = {
-            FinishReason.SAFETY,
-            FinishReason.RECITATION,
-            FinishReason.BLOCKLIST,
-            FinishReason.PROHIBITED_CONTENT,
-            FinishReason.SPII,
-            FinishReason.MALFORMED_FUNCTION_CALL,
-        }
-
         if response is None:
             raise ValueError(f"No response object from Gemini ({model})")
 
@@ -373,7 +382,7 @@ class GeminiProvider(BaseLLMProvider):
             f"thought_only={thought_only}"
         )
 
-        if finish_reason in BLOCKED_REASONS:
+        if finish_reason in BLOCKED_FINISH_REASONS:
             raise LLMBlockedError(
                 f"Gemini declined to answer ({model}): {detail}",
                 reason=getattr(finish_reason, "name", str(finish_reason)),
@@ -408,7 +417,17 @@ class GeminiProvider(BaseLLMProvider):
             history=history, new_message=message, file=file
         )
 
+        # `chunk.text` skips thought parts and function-call parts, so a stream
+        # can run to completion and hand the caller nothing at all. Without
+        # this tally the caller cannot tell that apart from a model that
+        # answered with silence, and the user gets a blank message with no
+        # error raised anywhere.
+        state: Dict[str, Any] = {"saw_text": False, "finish_reason": None}
+
         async def open_stream():
+            # A retry re-opens the stream, so what the previous attempt
+            # produced stops counting.
+            state.update(saw_text=False, finish_reason=None)
             return await self.client.aio.models.generate_content_stream(
                 model=model,
                 contents=contents,
@@ -416,8 +435,15 @@ class GeminiProvider(BaseLLMProvider):
                 **kwargs,
             )
 
+        def raise_if_no_answer() -> None:
+            if state["saw_text"]:
+                return
+            self._raise_for_empty_stream(state["finish_reason"], model)
+
         async for chunk in stream_with_retry(
-            open_stream, description=f"gemini/{model}"
+            open_stream,
+            description=f"gemini/{model}",
+            on_complete=raise_if_no_answer,
         ):
             if chunk is STREAM_RESTART:
                 yield StreamChunk(
@@ -428,14 +454,44 @@ class GeminiProvider(BaseLLMProvider):
                 )
                 continue
 
+            for candidate in getattr(chunk, "candidates", None) or []:
+                finish_reason = getattr(candidate, "finish_reason", None)
+                if finish_reason:
+                    state["finish_reason"] = finish_reason
+
+            text = chunk.text if chunk.text else ""
+            if text:
+                state["saw_text"] = True
+
             yield StreamChunk(
-                text=chunk.text if chunk.text else "",
+                text=text,
                 model=model,
                 provider=LLMProvider.GEMINI,
                 is_done=False,
             )
             if chunk.usage_metadata:
                 logger.debug(f"Gemini usage stats: {chunk.usage_metadata}")
+
+    @staticmethod
+    def _raise_for_empty_stream(finish_reason: Any, model: str) -> None:
+        """Classify a stream that ended having produced no answer text.
+
+        The same split the non-streaming path makes: a verdict the model
+        landed on is an LLMBlockedError, whose reason decides whether a fresh
+        draw is worth taking. Anything else — an exhausted output budget, a
+        bare STOP with nothing to show — is a transient miss worth re-issuing.
+        """
+        detail = f"finish_reason={finish_reason}"
+
+        if finish_reason in BLOCKED_FINISH_REASONS:
+            raise LLMBlockedError(
+                f"Gemini declined to answer ({model}): {detail}",
+                reason=getattr(finish_reason, "name", str(finish_reason)),
+            )
+
+        raise EmptyStreamError(
+            f"Gemini stream produced no answer text ({model}): {detail}"
+        )
 
     def _prepare_gemini_messages(
         self,
@@ -727,7 +783,13 @@ class OpenAIProvider(BaseLLMProvider):
         """Send streaming message to OpenAI"""
         messages = self._prepare_openai_messages(history, message, system_prompt, file)
 
+        # Same tally the Gemini path keeps: a stream that ends having produced
+        # no text is a failure, and returning it quietly hands the user a blank
+        # message with nothing raised anywhere.
+        state = {"saw_text": False}
+
         async def open_stream():
+            state["saw_text"] = False
             return await self._async_client.chat.completions.create(
                 model=model,
                 messages=messages,
@@ -736,8 +798,16 @@ class OpenAIProvider(BaseLLMProvider):
                 **kwargs,
             )
 
+        def raise_if_no_answer() -> None:
+            if not state["saw_text"]:
+                raise EmptyStreamError(
+                    f"OpenAI stream produced no answer text ({model})"
+                )
+
         async for chunk in stream_with_retry(
-            open_stream, description=f"openai/{model}"
+            open_stream,
+            description=f"openai/{model}",
+            on_complete=raise_if_no_answer,
         ):
             if chunk is STREAM_RESTART:
                 yield StreamChunk(
@@ -749,6 +819,7 @@ class OpenAIProvider(BaseLLMProvider):
                 continue
 
             if chunk.choices and chunk.choices[0].delta.content:
+                state["saw_text"] = True
                 yield StreamChunk(
                     text=chunk.choices[0].delta.content,
                     model=model,
@@ -1096,7 +1167,11 @@ class AnthropicProvider(BaseLLMProvider):
 
         params.update(kwargs)
 
+        state = {"saw_text": False}
+
         async def open_stream():
+            state["saw_text"] = False
+
             async def text_chunks():
                 async with self._async_client.messages.stream(**params) as stream:
                     async for text in stream.text_stream:
@@ -1109,8 +1184,16 @@ class AnthropicProvider(BaseLLMProvider):
 
             return text_chunks()
 
+        def raise_if_no_answer() -> None:
+            if not state["saw_text"]:
+                raise EmptyStreamError(
+                    f"Anthropic stream produced no answer text ({model})"
+                )
+
         async for text in stream_with_retry(
-            open_stream, description=f"anthropic/{model}"
+            open_stream,
+            description=f"anthropic/{model}",
+            on_complete=raise_if_no_answer,
         ):
             if text is STREAM_RESTART:
                 yield StreamChunk(
@@ -1120,6 +1203,9 @@ class AnthropicProvider(BaseLLMProvider):
                     is_restart=True,
                 )
                 continue
+
+            if text:
+                state["saw_text"] = True
 
             yield StreamChunk(
                 text=text,

--- a/server/app/llm/utils.py
+++ b/server/app/llm/utils.py
@@ -19,10 +19,17 @@ class LLMBlockedError(Exception):
     (safety filter, recitation, prompt-level block, malformed function call).
 
     `reason` is the provider's finish reason as a bare name (e.g. "RECITATION"),
-    so callers can tell the terminal blocks apart from the one that isn't:
-    recitation depends on the sampled continuation, not on anything stable about
-    the request.
+    so callers can tell the terminal blocks apart from the ones that aren't:
+    some verdicts depend on the sampled continuation, not on anything stable
+    about the request.
     """
+
+    # Verdicts that are a property of the draw rather than of the request, so a
+    # fresh sample usually clears them. RECITATION fires when a continuation
+    # wanders into memorized text. MALFORMED_FUNCTION_CALL fires when the model
+    # emits a function call the request never offered it — which, on a request
+    # carrying no tools at all, is purely a sampling accident.
+    RESAMPLABLE_REASONS = frozenset({"RECITATION", "MALFORMED_FUNCTION_CALL"})
 
     def __init__(self, message: str, reason: str | None = None):
         super().__init__(message)
@@ -31,6 +38,19 @@ class LLMBlockedError(Exception):
     @property
     def is_recitation(self) -> bool:
         return self.reason == "RECITATION"
+
+    @property
+    def is_resamplable(self) -> bool:
+        return self.reason in self.RESAMPLABLE_REASONS
+
+
+class EmptyStreamError(Exception):
+    """A stream finished cleanly without producing any answer text.
+
+    Distinct from LLMBlockedError: nothing refused the request. The model ran
+    out of output budget mid-thought, or stopped with nothing visible to show.
+    Re-issuing the request is worth a try.
+    """
 
 
 # Exceptions that should trigger a retry with backoff. LLMBlockedError is
@@ -142,6 +162,11 @@ RETRYABLE_STREAM_EXCEPTIONS = (
 )
 
 
+# What a re-issued request can plausibly fix: the connection died with bytes
+# still owed, or the stream ran to completion having produced nothing to read.
+RETRYABLE_STREAM_FAILURES = RETRYABLE_STREAM_EXCEPTIONS + (EmptyStreamError,)
+
+
 class _StreamRestart:
     """Marker yielded when a dropped stream is being retried from scratch."""
 
@@ -158,6 +183,7 @@ async def stream_with_retry(
     max_retries: int = 2,
     delay: float = 1.0,
     description: str = "stream",
+    on_complete: Callable[[], None] | None = None,
 ) -> AsyncIterator[Any]:
     """Iterate an upstream LLM stream, re-issuing the whole request if the
     connection drops mid-body.
@@ -170,6 +196,14 @@ async def stream_with_retry(
     text, not a continuation — so when chunks were already emitted before the
     drop, STREAM_RESTART is yielded first. Callers must treat it as "discard
     everything received so far"; what follows is a complete replacement answer.
+
+    `on_complete` runs after a stream ends without a transport error, and is
+    where the caller decides whether what arrived was actually an answer. A
+    stream can finish cleanly having produced nothing a reader can see — every
+    part a thought, a recitation verdict, an output budget spent before the
+    first visible token — and without this hook that is indistinguishable from
+    a model that chose to say nothing. Raising from it re-enters the retry
+    logic below.
     """
     for attempt in range(max_retries + 1):
         emitted = False
@@ -178,11 +212,27 @@ async def stream_with_retry(
             async for chunk in stream:
                 emitted = True
                 yield chunk
+            if on_complete is not None:
+                on_complete()
             return
-        except RETRYABLE_STREAM_EXCEPTIONS as e:
+        except LLMBlockedError as e:
+            # Some verdicts are a property of the sampled continuation, not of
+            # the request, so one fresh draw usually clears them. The rest —
+            # safety, blocklist, prohibited content — are stable, and
+            # re-sampling only burns time and tokens.
+            if not e.is_resamplable or attempt >= max_retries:
+                raise
+            logger.warning(
+                f"{description}: {e.reason} block after emitting={emitted}. "
+                f"Resampling {attempt+1}/{max_retries}."
+            )
+            await asyncio.sleep(delay * (2**attempt) * (0.5 + 0.5 * random.random()))
+            if emitted:
+                yield STREAM_RESTART
+        except RETRYABLE_STREAM_FAILURES as e:
             if attempt >= max_retries:
                 logger.error(
-                    f"{description}: stream dropped after {max_retries} retries: "
+                    f"{description}: stream failed after {max_retries} retries: "
                     f"{type(e).__name__}: {e}",
                     exc_info=e,
                 )
@@ -190,7 +240,7 @@ async def stream_with_retry(
 
             backoff_time = delay * (2**attempt) * (0.5 + 0.5 * random.random())
             logger.warning(
-                f"{description}: stream dropped ({type(e).__name__}: {str(e)[:120]}) "
+                f"{description}: stream failed ({type(e).__name__}: {str(e)[:120]}) "
                 f"after emitting={emitted}. Retry {attempt+1}/{max_retries} "
                 f"in {backoff_time:.2f}s"
             )

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -103,11 +103,25 @@ setup_admin(app)  # Setup admin interface
 
 if __name__ == "__main__":
     port = int(os.getenv("PORT", "8000"))
+
+    # Production never reaches this block: the image's CMD is gunicorn, which
+    # imports `app.main:app` and never runs __main__. So the reloader is
+    # dev-only by construction. It is still gated on an env var rather than
+    # switched on outright, because start.sh routes the uncontainerized
+    # `uv run start` through here too, and that is someone's own setup to
+    # decide about. The containerized stack sets UVICORN_RELOAD itself.
+    reload = os.getenv("UVICORN_RELOAD", "").strip().lower() in {"1", "true", "yes"}
+
     uvicorn.run(
         "app.main:app",
         host="0.0.0.0",
         port=port,
-        # reload=True,
+        reload=reload,
+        # Only the application package. The server directory also holds eval
+        # fixtures, dev tooling and tests — none of them should trigger a
+        # restart, and the seed PDFs would make the watcher needlessly
+        # expensive.
+        reload_dirs=[os.path.dirname(os.path.abspath(__file__))] if reload else None,
         log_level="debug",  # Set higher log level to see more details
         log_config=None,  # Keep the handlers configure_logging() installed
         forwarded_allow_ips="*",  # Allow all forwarded IPs

--- a/server/tests/test_empty_answer_stream.py
+++ b/server/tests/test_empty_answer_stream.py
@@ -1,0 +1,237 @@
+"""What happens when the answer model streams no answer.
+
+A Gemini stream can run to completion and hand the caller nothing a reader can
+see. The model emits a function call the request never offered it and the
+candidate is cut short as MALFORMED_FUNCTION_CALL; it spends its whole output
+budget thinking; a continuation wanders into memorized text and trips
+RECITATION. In every case `chunk.text` skips the parts that are there, the
+stream ends normally, and — before these tests — that was indistinguishable
+from a model that chose to answer with silence.
+
+The user saw a blank message. No error was raised, so nothing retried; no error
+chunk reached the client; and the blank turn was saved, which then replayed an
+empty model part into the history of every later turn in the conversation.
+
+These tests hold three seams: an empty stream raises rather than returning
+quietly, the reasons that a fresh draw can clear are re-sampled while the ones
+it cannot are not, and a turn that still ends with no text tells the user so
+instead of persisting a blank.
+"""
+
+import asyncio
+import json
+import os
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from app.api.message_api import _stream_chat_chunks
+from app.llm.provider import GeminiProvider
+from app.llm.utils import (
+    STREAM_RESTART,
+    EmptyStreamError,
+    LLMBlockedError,
+    stream_with_retry,
+)
+from google.genai.types import FinishReason
+
+
+def chunk(text=None, finish_reason=None):
+    """A stream chunk shaped like the SDK's.
+
+    `text` is None for a chunk carrying only a thought or a function call —
+    the case the whole bug turns on.
+    """
+    return SimpleNamespace(
+        text=text,
+        usage_metadata=None,
+        candidates=[SimpleNamespace(finish_reason=finish_reason)],
+    )
+
+
+class EmptyGeminiStreamTest(unittest.IsolatedAsyncioTestCase):
+    def make_provider(self, script):
+        with patch.dict(os.environ, {"GEMINI_API_KEY": "test-key"}):
+            provider = GeminiProvider()
+
+        attempts = {"n": 0}
+
+        async def generate_content_stream(**kwargs):
+            attempts["n"] += 1
+            n = attempts["n"]
+
+            async def gen():
+                for item in script(n):
+                    yield item
+
+            return gen()
+
+        provider._client = SimpleNamespace(
+            aio=SimpleNamespace(
+                models=SimpleNamespace(generate_content_stream=generate_content_stream)
+            )
+        )
+        return provider, attempts
+
+    async def stream(self, provider):
+        return [
+            c
+            async for c in provider.send_message_stream(
+                model="gemini-3.6-flash",
+                message="q",
+                history=[],
+                system_prompt="s",
+            )
+        ]
+
+    async def test_malformed_function_call_is_resampled(self):
+        """The reproduced failure: a stray function call on a request with no
+        tools. Nothing refused the request, so a fresh draw answers it."""
+
+        def script(attempt):
+            if attempt == 1:
+                return [chunk(finish_reason=FinishReason.MALFORMED_FUNCTION_CALL)]
+            return [chunk(text="the answer", finish_reason=FinishReason.STOP)]
+
+        provider, attempts = self.make_provider(script)
+        chunks = await self.stream(provider)
+
+        self.assertEqual(attempts["n"], 2)
+        self.assertEqual([c.text for c in chunks if c.text], ["the answer"])
+
+    async def test_recitation_is_resampled(self):
+        def script(attempt):
+            if attempt == 1:
+                return [chunk(finish_reason=FinishReason.RECITATION)]
+            return [chunk(text="the answer", finish_reason=FinishReason.STOP)]
+
+        provider, attempts = self.make_provider(script)
+        chunks = await self.stream(provider)
+
+        self.assertEqual(attempts["n"], 2)
+        self.assertEqual([c.text for c in chunks if c.text], ["the answer"])
+
+    async def test_safety_block_is_not_resampled(self):
+        """A safety verdict is stable. Re-sampling only burns time and tokens,
+        so it surfaces on the first attempt."""
+
+        def script(attempt):
+            return [chunk(finish_reason=FinishReason.SAFETY)]
+
+        provider, attempts = self.make_provider(script)
+        with self.assertRaises(LLMBlockedError) as caught:
+            await self.stream(provider)
+
+        self.assertEqual(attempts["n"], 1)
+        self.assertEqual(caught.exception.reason, "SAFETY")
+
+    async def test_thought_only_stream_raises_after_retries(self):
+        """Budget spent before the first visible token. Nothing refused, so it
+        is retried — but a stream that never produces text must not be
+        reported as a successful empty answer."""
+
+        def script(attempt):
+            return [chunk(), chunk(finish_reason=FinishReason.MAX_TOKENS)]
+
+        provider, attempts = self.make_provider(script)
+        with self.assertRaises(EmptyStreamError):
+            await self.stream(provider)
+
+        self.assertEqual(attempts["n"], 3)
+
+    async def test_text_stream_is_left_alone(self):
+        def script(attempt):
+            return [chunk(text="the answer", finish_reason=FinishReason.STOP)]
+
+        provider, attempts = self.make_provider(script)
+        chunks = await self.stream(provider)
+
+        self.assertEqual(attempts["n"], 1)
+        self.assertEqual([c.text for c in chunks], ["the answer"])
+
+
+class StreamWithRetryOnCompleteTest(unittest.IsolatedAsyncioTestCase):
+    """The contract every provider now leans on.
+
+    Gemini classifies its finish reason, OpenAI and Anthropic just check
+    whether any text arrived — but all three report an empty stream by raising
+    from `on_complete`, and rely on this to turn that into a fresh request.
+    """
+
+    async def run_stream(self, script, on_complete):
+        attempts = {"n": 0}
+
+        async def open_stream():
+            attempts["n"] += 1
+            n = attempts["n"]
+
+            async def gen():
+                for item in script(n):
+                    yield item
+
+            return gen()
+
+        collected = [
+            item
+            async for item in stream_with_retry(
+                open_stream,
+                delay=0.0,
+                description="test",
+                on_complete=lambda: on_complete(attempts["n"]),
+            )
+        ]
+        return collected, attempts["n"]
+
+    async def test_on_complete_runs_after_a_clean_stream(self):
+        calls = []
+
+        collected, attempts = await self.run_stream(
+            lambda n: ["a", "b"], lambda n: calls.append(n)
+        )
+
+        self.assertEqual(collected, ["a", "b"])
+        self.assertEqual(attempts, 1)
+        self.assertEqual(calls, [1])
+
+    async def test_raising_from_on_complete_re_issues_the_request(self):
+        def on_complete(attempt):
+            if attempt == 1:
+                raise EmptyStreamError("nothing to show")
+
+        collected, attempts = await self.run_stream(lambda n: ["a"], on_complete)
+
+        self.assertEqual(attempts, 2)
+        # The first attempt emitted a chunk before turning out to be empty, so
+        # the caller is told to discard it rather than append to it.
+        self.assertIn(STREAM_RESTART, collected)
+
+
+class ErrorChunkReachesTheClientTest(unittest.IsolatedAsyncioTestCase):
+    """chat_with_papers reports a failed answer stream as an error chunk.
+
+    _stream_chat_chunks used to have no branch for it, so the one signal that
+    something went wrong was dropped between the generator and the client.
+    """
+
+    async def test_error_chunk_is_forwarded(self):
+        async def generator():
+            yield {"type": "status", "content": "Reading papers..."}
+            yield {"type": "error", "content": "Sorry, an error occurred."}
+
+        content_chunks: list = []
+        emitted = [
+            event
+            async for event in _stream_chat_chunks(
+                chunk_generator=generator(),
+                content_chunks=content_chunks,
+                evidence_container={"evidence": None},
+            )
+        ]
+
+        types = [json.loads(e.split("END_OF_STREAM")[0])["type"] for e in emitted]
+        self.assertEqual(types, ["status", "error"])
+        self.assertEqual(content_chunks, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
addresses #77 

improve project answering in two main ways: (1) allow model to gather more context about where it sits, in a project, general chat across the collection, or scoped chat, and (2) handle botched responses when model responded with an impossible action (e.g., a tool call request in the final response) with retries, and (3) fallback to sharing abstracts when evidence gathering doesn't return results.

bonus: add reload to the dev server with the local development docker setup.