### PR TITLE
add better handling for certain zotero errors

### DIFF
--- a/client/src/components/zotero/ZoteroIntegrationCard.tsx
+++ b/client/src/components/zotero/ZoteroIntegrationCard.tsx
@@ -23,7 +23,9 @@ import {
 import {
 	computeImportProgress,
 	defaultZoteroSelection,
+	describeFailureGroup,
 	formatZoteroLastSynced,
+	groupImportFailures,
 } from "./utils";
 
 export function ZoteroIntegrationCard() {
@@ -118,6 +120,21 @@ export function ZoteroIntegrationCard() {
 	);
 
 	const showSyncAnnotations = recentImportsLoaded && hasSyncableImports;
+
+	// The import toast is transient, but /import/status keeps the reason on each
+	// failed row — so the explanation survives a dismissed toast or a reload.
+	const failedImportGroups = useMemo(() => {
+		const failures = recentImports
+			.filter((i) => i.status === "failed" && i.error_message)
+			.map((i) => ({
+				zotero_item_key: i.zotero_item_key,
+				message: i.error_message as string,
+			}));
+		const keyToTitle = new Map(
+			recentImports.map((i) => [i.zotero_item_key, i.title])
+		);
+		return groupImportFailures(failures, (key) => keyToTitle.get(key));
+	}, [recentImports]);
 
 	useEffect(() => {
 		const zoteroParam = searchParams.get("zotero");
@@ -255,15 +272,19 @@ export function ZoteroIntegrationCard() {
 		}
 		if (hasDetailToast) {
 			const keyToTitle = new Map(libraryItems.map((i) => [i.zotero_item_key, i.title]));
-			toast.error("", {
+			const groups = groupImportFailures(
+				data.errors.map((e) => ({ zotero_item_key: e.zotero_item_key, message: e.error })),
+				(key) => keyToTitle.get(key),
+			);
+			toast.error(`${errorCount} paper${errorCount === 1 ? "" : "s"} could not be imported`, {
 				description: (
 					<ul className="mt-1 space-y-2 list-none">
-						{data.errors.map((e) => (
-							<li key={e.zotero_item_key}>
-								<span className="font-medium block">
-									{keyToTitle.get(e.zotero_item_key) ?? e.zotero_item_key}
+						{groups.map((group) => (
+							<li key={group.message}>
+								<span className="block">{group.message}</span>
+								<span className="block text-xs mt-0.5 opacity-75">
+									{describeFailureGroup(group)}
 								</span>
-								<span className="block text-xs mt-0.5 opacity-75">{e.error}</span>
 							</li>
 						))}
 					</ul>
@@ -432,6 +453,23 @@ export function ZoteroIntegrationCard() {
 			</div>
 					{importProgress !== null && importTotal !== null && (
 						<Progress value={importProgress} />
+					)}
+					{failedImportGroups.length > 0 && (
+						<div className="rounded-md bg-muted p-3 space-y-2">
+							<p className="text-sm font-medium text-yellow-700 dark:text-yellow-400">
+								Some papers could not be imported
+							</p>
+							<ul className="space-y-2 list-none">
+								{failedImportGroups.map((group) => (
+									<li key={group.message}>
+										<p className="text-sm">{group.message}</p>
+										<p className="text-xs text-muted-foreground">
+											{describeFailureGroup(group)}
+										</p>
+									</li>
+								))}
+							</ul>
+						</div>
 					)}
 					</div>
 					) : (

--- a/client/src/components/zotero/types.ts
+++ b/client/src/components/zotero/types.ts
@@ -10,6 +10,7 @@ export type ZoteroImportStatusItem = {
 	status: string;
 	import_source: string;
 	title?: string;
+	error_message?: string;
 	created_at?: string;
 };
 

--- a/client/src/components/zotero/utils.ts
+++ b/client/src/components/zotero/utils.ts
@@ -37,3 +37,53 @@ export function defaultZoteroSelection(
 		.map((i) => i.zotero_item_key);
 	return new Set(keys);
 }
+
+export type ImportFailureGroup = {
+	message: string;
+	/** Titles we could resolve; may be shorter than `count`. */
+	titles: string[];
+	count: number;
+};
+
+/**
+ * Group import failures by their message.
+ *
+ * A single account-level cause (Zotero File Storage not holding the files, say)
+ * fails every selected paper with the same explanation, so listing them per item
+ * repeats one sentence N times. Grouping states the cause once and names the
+ * papers it applies to.
+ *
+ * A failure that happens before the paper row exists has no title to look up, so
+ * `count` is tracked separately and callers can fall back to it rather than
+ * printing an opaque Zotero item key.
+ */
+export function groupImportFailures(
+	failures: { zotero_item_key: string; message: string }[],
+	titleFor: (key: string) => string | undefined,
+): ImportFailureGroup[] {
+	const groups = new Map<string, ImportFailureGroup>();
+	for (const failure of failures) {
+		const group = groups.get(failure.message) ?? {
+			message: failure.message,
+			titles: [],
+			count: 0,
+		};
+		const title = titleFor(failure.zotero_item_key);
+		if (title) group.titles.push(title);
+		group.count += 1;
+		groups.set(failure.message, group);
+	}
+	return Array.from(groups.values());
+}
+
+/**
+ * Name the papers in a failure group: their titles when we have them, and a
+ * plain count when the failure predates the paper row.
+ */
+export function describeFailureGroup(group: ImportFailureGroup): string {
+	if (group.titles.length === group.count) return group.titles.join(", ");
+	if (group.titles.length > 0) {
+		return `${group.titles.join(", ")} and ${group.count - group.titles.length} more`;
+	}
+	return `${group.count} paper${group.count === 1 ? "" : "s"}`;
+}

--- a/server/app/helpers/exa_search.py
+++ b/server/app/helpers/exa_search.py
@@ -9,6 +9,7 @@ from typing import Optional
 from urllib.parse import unquote, urlparse
 
 import httpx
+from app.helpers.http_retry import is_retryable_status, retryable_status_in_message
 from exa_py import Exa
 
 logger = logging.getLogger(__name__)
@@ -28,7 +29,6 @@ EXA_REQUEST_TIMEOUT = 60.0
 # message embeds the HTTP status, and surfaces transport failures as httpx errors.
 EXA_MAX_RETRIES = 2
 EXA_RETRY_BASE_DELAY = 1.0
-_RETRYABLE_STATUS_CODES = {429, 500, 502, 503, 504}
 
 # Publication entities expose a DOI directly on some results and only as a
 # doi.org link on others; either is enough to look the work up in OpenAlex.
@@ -42,14 +42,14 @@ def _is_retryable_exa_error(e: Exception) -> bool:
     # A response we did receive is retryable only for the transient status codes;
     # checked before HTTPError since it is a subclass.
     if isinstance(e, httpx.HTTPStatusError):
-        return e.response.status_code in _RETRYABLE_STATUS_CODES
+        return is_retryable_status(e.response.status_code)
     # Transport-level failures (timeouts, connection resets) are transient.
     if isinstance(e, httpx.HTTPError):
         return True
     # exa_py raises ValueError("Request failed with status code <N>: ...").
-    match = re.search(r"status code (\d{3})", str(e))
-    if match:
-        return int(match.group(1)) in _RETRYABLE_STATUS_CODES
+    from_message = retryable_status_in_message(str(e))
+    if from_message is not None:
+        return from_message
     return False
 
 

--- a/server/app/helpers/http_retry.py
+++ b/server/app/helpers/http_retry.py
@@ -1,0 +1,44 @@
+"""Shared retry classification for outbound HTTP calls.
+
+Every third-party client we retry against wants the same rule — retry transport
+failures and transient server responses, give up immediately on a 4xx that will
+never succeed — but each surfaces failures through a different exception type.
+The status set and the rule live here; the per-library predicates that map an
+exception onto it live next to their client.
+"""
+
+import re
+from typing import Optional
+
+# 429 is included because it is transient by definition: the caller is expected
+# to wait and try again. Every other 4xx describes a request that is wrong on its
+# own terms (bad params, missing resource, bad credentials) and retrying it only
+# multiplies the latency and the log noise.
+RETRYABLE_STATUS_CODES = frozenset({429, 500, 502, 503, 504})
+
+# Clients that only expose the status inside an exception message, e.g. exa_py's
+# ValueError("Request failed with status code 502: ...").
+_STATUS_IN_MESSAGE = re.compile(r"status code (\d{3})")
+
+
+def is_retryable_status(status_code: Optional[int]) -> bool:
+    """True if an HTTP status is worth retrying.
+
+    An unknown status (None) is treated as retryable: it means we never got a
+    response, which is the transport-failure case.
+    """
+    if status_code is None:
+        return True
+    return status_code in RETRYABLE_STATUS_CODES
+
+
+def retryable_status_in_message(message: str) -> Optional[bool]:
+    """Classify a failure whose status is only present in its message text.
+
+    Returns None when no status could be found, so callers can fall back to
+    their own heuristics rather than treating "unparseable" as "not retryable".
+    """
+    match = _STATUS_IN_MESSAGE.search(message)
+    if not match:
+        return None
+    return is_retryable_status(int(match.group(1)))

--- a/server/app/integrations/zotero_api.py
+++ b/server/app/integrations/zotero_api.py
@@ -4,12 +4,26 @@ import time
 from typing import Any, Dict, List, Optional
 
 import requests
+from app.helpers.http_retry import is_retryable_status
 
 logger = logging.getLogger(__name__)
 
 ZOTERO_API_BASE = "https://api.zotero.org"
 MAX_RETRIES = 3
 IMPORTABLE_ITEM_TYPES = ("journalArticle", "conferencePaper", "preprint")
+
+
+class ZoteroFileNotStoredError(Exception):
+    """An attachment's file is not retrievable from Zotero File Storage.
+
+    Zotero's ``linkMode`` only records that the user stored a copy of the file,
+    not that the bytes reached Zotero's servers. Files synced over WebDAV, never
+    uploaded, or blocked by a full storage quota keep ``imported_file`` and 404
+    on the file endpoint — the API docs note a file "may be available only via
+    WebDAV, not via Zotero File Storage, and it is up to the client how to
+    proceed". This is an expected account state, not a bug, so it is raised
+    distinctly to let callers explain it rather than reporting a generic failure.
+    """
 
 
 class ZoteroApiClient:
@@ -77,8 +91,10 @@ class ZoteroApiClient:
                 # raise_for_status()'s message omits the response body, which is
                 # where Zotero explains *why* the call failed — capture it here.
                 resp = getattr(e, "response", None)
-                status = resp.status_code if resp is not None else "no response"
+                status_code = resp.status_code if resp is not None else None
+                status = status_code if status_code is not None else "no response"
                 body = resp.text[:500] if resp is not None and resp.text else ""
+                retryable = is_retryable_status(status_code)
                 logger.warning(
                     "Zotero API request failed: %s %s -> %s (attempt %d/%d): %s%s",
                     method,
@@ -89,6 +105,12 @@ class ZoteroApiClient:
                     e,
                     f" | body: {body}" if body else "",
                 )
+                # A 4xx describes a request that is wrong on its own terms — most
+                # often a 404 for an attachment whose file was never uploaded to
+                # Zotero File Storage. Retrying only multiplies the latency of a
+                # bulk import and turns an expected data condition into an ERROR.
+                if not retryable:
+                    raise
                 if attempt < MAX_RETRIES - 1:
                     time.sleep(2**attempt)
         logger.error(
@@ -280,7 +302,13 @@ class ZoteroApiClient:
 
     def download_attachment_file(self, attachment_key: str) -> bytes:
         url = f"{self._user_base}/items/{attachment_key}/file"
-        response = self._request("GET", url, stream=True)
+        try:
+            response = self._request("GET", url, stream=True)
+        except requests.HTTPError as e:
+            resp = getattr(e, "response", None)
+            if resp is not None and resp.status_code == 404:
+                raise ZoteroFileNotStoredError(attachment_key) from e
+            raise
         return response.content
 
     @staticmethod

--- a/server/app/integrations/zotero_api.py
+++ b/server/app/integrations/zotero_api.py
@@ -1,7 +1,7 @@
 import json
 import logging
 import time
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, FrozenSet, List, Optional
 
 import requests
 from app.helpers.http_retry import is_retryable_status
@@ -51,7 +51,14 @@ class ZoteroApiClient:
         *,
         params: Optional[Dict[str, Any]] = None,
         stream: bool = False,
+        expected_statuses: FrozenSet[int] = frozenset(),
     ) -> requests.Response:
+        """Issue a Zotero request, retrying only transient failures.
+
+        ``expected_statuses`` names statuses that are a normal outcome for the
+        endpoint rather than a fault; they are still logged, at INFO instead of
+        WARNING, so they stay available for analysis without reading as errors.
+        """
         last_error: Optional[Exception] = None
         for attempt in range(MAX_RETRIES):
             try:
@@ -95,15 +102,36 @@ class ZoteroApiClient:
                 status = status_code if status_code is not None else "no response"
                 body = resp.text[:500] if resp is not None and resp.text else ""
                 retryable = is_retryable_status(status_code)
-                logger.warning(
-                    "Zotero API request failed: %s %s -> %s (attempt %d/%d): %s%s",
+                # Saying "attempt 1/3" for a status we are about to give up on
+                # would promise two more lines that never arrive.
+                progress = (
+                    f"attempt {attempt + 1}/{MAX_RETRIES}"
+                    if retryable
+                    else "not retryable"
+                )
+                logger.log(
+                    # A status the caller declared normal for this endpoint is a
+                    # data condition, not a fault, so it stays queryable without
+                    # competing with real failures.
+                    (
+                        logging.INFO
+                        if status_code in expected_statuses
+                        else logging.WARNING
+                    ),
+                    "Zotero API request failed: %s %s -> %s (%s): %s%s",
                     method,
                     url,
                     status,
-                    attempt + 1,
-                    MAX_RETRIES,
+                    progress,
                     e,
                     f" | body: {body}" if body else "",
+                    # Structured so these can be counted and grouped by status or
+                    # endpoint without parsing the message text.
+                    extra={
+                        "zotero_status": status_code,
+                        "zotero_method": method,
+                        "zotero_url": url,
+                    },
                 )
                 # A 4xx describes a request that is wrong on its own terms — most
                 # often a 404 for an attachment whose file was never uploaded to
@@ -303,7 +331,9 @@ class ZoteroApiClient:
     def download_attachment_file(self, attachment_key: str) -> bytes:
         url = f"{self._user_base}/items/{attachment_key}/file"
         try:
-            response = self._request("GET", url, stream=True)
+            response = self._request(
+                "GET", url, stream=True, expected_statuses=frozenset({404})
+            )
         except requests.HTTPError as e:
             resp = getattr(e, "response", None)
             if resp is not None and resp.status_code == 404:

--- a/server/app/services/zotero_import.py
+++ b/server/app/services/zotero_import.py
@@ -536,10 +536,17 @@ async def _resolve_pdf_bytes(
             except ZoteroFileNotStoredError:
                 # Expected account state rather than a fault, so it is logged
                 # without a stack trace and explained in the user's own terms.
+                # Kept at INFO with structured keys so the rate of storage-blocked
+                # imports stays measurable without reading as a failure.
                 logger.info(
                     "Zotero attachment %s for item %s is not in Zotero File Storage",
                     attachment_key,
                     item_key,
+                    extra={
+                        "zotero_item_key": item_key,
+                        "zotero_attachment_key": attachment_key,
+                        "zotero_failure": "file_not_stored",
+                    },
                 )
                 failure_reason = FILE_NOT_STORED_MESSAGE
             except Exception as e:

--- a/server/app/services/zotero_import.py
+++ b/server/app/services/zotero_import.py
@@ -38,7 +38,7 @@ from app.helpers.subscription_limits import (
     can_user_upload_paper,
     get_remaining_paper_upload_slots,
 )
-from app.integrations.zotero_api import ZoteroApiClient
+from app.integrations.zotero_api import ZoteroApiClient, ZoteroFileNotStoredError
 from app.llm.utils import find_offsets
 from app.schemas.user import CurrentUser
 from sqlalchemy.orm import Session
@@ -46,6 +46,15 @@ from sqlalchemy.orm import Session
 logger = logging.getLogger(__name__)
 
 ZOTERO_IMPORT_CONCURRENCY = 10
+
+# Phrased like the linked-file/linked-URL reasons below: what is wrong, then what
+# to change in Zotero. The cause is on the user's Zotero account rather than in
+# their library metadata, so there is nothing we can detect ahead of the download.
+FILE_NOT_STORED_MESSAGE = (
+    "PDF is not stored in Zotero's cloud, so it cannot be downloaded. "
+    "In Zotero, check Settings → Sync → File Syncing: syncing may be off, set to "
+    "WebDAV, or your storage may be full."
+)
 
 
 class ImportErrorResult(TypedDict):
@@ -524,6 +533,15 @@ async def _resolve_pdf_bytes(
                     "Zotero PDF attachment invalid for %s: %s", item_key, err
                 )
                 failure_reason = f"PDF attachment could not be validated: {err}"
+            except ZoteroFileNotStoredError:
+                # Expected account state rather than a fault, so it is logged
+                # without a stack trace and explained in the user's own terms.
+                logger.info(
+                    "Zotero attachment %s for item %s is not in Zotero File Storage",
+                    attachment_key,
+                    item_key,
+                )
+                failure_reason = FILE_NOT_STORED_MESSAGE
             except Exception as e:
                 logger.warning(
                     "Failed to download Zotero PDF for %s: %s",

--- a/server/tests/test_zotero_retry.py
+++ b/server/tests/test_zotero_retry.py
@@ -1,0 +1,205 @@
+import asyncio
+import unittest
+from unittest.mock import MagicMock, patch
+
+import requests
+from app.helpers.http_retry import is_retryable_status, retryable_status_in_message
+from app.integrations.zotero_api import (
+    MAX_RETRIES,
+    ZoteroApiClient,
+    ZoteroFileNotStoredError,
+)
+from app.services.zotero_import import FILE_NOT_STORED_MESSAGE, _resolve_pdf_bytes
+
+
+def _response(status_code: int, body: str = "") -> MagicMock:
+    """A requests.Response stand-in that raises like the real thing."""
+    response = MagicMock(spec=requests.Response)
+    response.status_code = status_code
+    response.text = body
+    response.headers = {}
+    response.content = b"%PDF-1.4 body"
+    if status_code >= 400:
+        response.raise_for_status.side_effect = requests.HTTPError(
+            f"{status_code} Error for url: https://api.zotero.org/x", response=response
+        )
+    else:
+        response.raise_for_status.return_value = None
+    return response
+
+
+class TestRetryableStatus(unittest.TestCase):
+    def test_transient_statuses_are_retryable(self) -> None:
+        for code in (429, 500, 502, 503, 504):
+            self.assertTrue(is_retryable_status(code), code)
+
+    def test_client_errors_are_not_retryable(self) -> None:
+        for code in (400, 401, 403, 404, 409):
+            self.assertFalse(is_retryable_status(code), code)
+
+    def test_no_response_is_retryable(self) -> None:
+        """A transport failure never produced a status; treat it as transient."""
+        self.assertTrue(is_retryable_status(None))
+
+    def test_status_parsed_out_of_message(self) -> None:
+        self.assertTrue(retryable_status_in_message("failed with status code 502: x"))
+        self.assertFalse(retryable_status_in_message("failed with status code 404: x"))
+
+    def test_unparseable_message_is_undecided(self) -> None:
+        self.assertIsNone(retryable_status_in_message("something else entirely"))
+
+
+class TestZoteroRequestRetries(unittest.TestCase):
+    def setUp(self) -> None:
+        self.client = ZoteroApiClient(zotero_user_id="123", api_key="k")
+
+    def _run(self, status_code: int):
+        with (
+            patch.object(self.client._session, "request") as request,
+            patch("app.integrations.zotero_api.time.sleep") as sleep,
+        ):
+            request.return_value = _response(status_code, "Not found")
+            with self.assertRaises(requests.HTTPError):
+                self.client._request("GET", "https://api.zotero.org/x")
+            return request.call_count, sleep.call_count
+
+    def test_404_is_not_retried(self) -> None:
+        """The file endpoint 404s for attachments Zotero never stored; retrying
+        that only multiplies the latency of a bulk import."""
+        calls, sleeps = self._run(404)
+        self.assertEqual(calls, 1)
+        self.assertEqual(sleeps, 0)
+
+    def test_403_is_not_retried(self) -> None:
+        calls, _ = self._run(403)
+        self.assertEqual(calls, 1)
+
+    def test_server_error_is_retried(self) -> None:
+        calls, _ = self._run(503)
+        self.assertEqual(calls, MAX_RETRIES)
+
+    def test_transport_error_is_retried(self) -> None:
+        with (
+            patch.object(self.client._session, "request") as request,
+            patch("app.integrations.zotero_api.time.sleep"),
+        ):
+            request.side_effect = requests.ConnectionError("connection reset")
+            with self.assertRaises(requests.ConnectionError):
+                self.client._request("GET", "https://api.zotero.org/x")
+            self.assertEqual(request.call_count, MAX_RETRIES)
+
+    def test_rate_limit_is_retried(self) -> None:
+        with (
+            patch.object(self.client._session, "request") as request,
+            patch("app.integrations.zotero_api.time.sleep"),
+        ):
+            request.return_value = _response(429)
+            with self.assertRaises(requests.HTTPError):
+                self.client._request("GET", "https://api.zotero.org/x")
+            self.assertEqual(request.call_count, MAX_RETRIES)
+
+
+class TestFailureLogging(unittest.TestCase):
+    """A failure we choose not to retry still has to stay analyzable."""
+
+    def setUp(self) -> None:
+        self.client = ZoteroApiClient(zotero_user_id="123", api_key="k")
+
+    def _capture(self, status_code: int, **kwargs):
+        with (
+            patch.object(self.client._session, "request") as request,
+            patch("app.integrations.zotero_api.time.sleep"),
+            self.assertLogs("app.integrations.zotero_api", level="INFO") as logs,
+        ):
+            request.return_value = _response(status_code, "Not found")
+            with self.assertRaises(requests.HTTPError):
+                self.client._request("GET", "https://api.zotero.org/x", **kwargs)
+            return logs.records
+
+    def test_expected_status_logs_at_info(self) -> None:
+        records = self._capture(404, expected_statuses=frozenset({404}))
+        self.assertEqual([r.levelname for r in records], ["INFO"])
+
+    def test_unexpected_client_error_stays_a_warning(self) -> None:
+        records = self._capture(404)
+        self.assertEqual([r.levelname for r in records], ["WARNING"])
+
+    def test_no_error_level_record_for_a_404(self) -> None:
+        """The give-up ERROR is for exhausted retries, not for a 404."""
+        records = self._capture(404, expected_statuses=frozenset({404}))
+        self.assertNotIn("ERROR", [r.levelname for r in records])
+
+    def test_status_is_recorded_as_a_structured_field(self) -> None:
+        record = self._capture(404, expected_statuses=frozenset({404}))[0]
+        self.assertEqual(record.zotero_status, 404)
+        self.assertEqual(record.zotero_url, "https://api.zotero.org/x")
+
+    def test_non_retryable_failure_does_not_claim_more_attempts(self) -> None:
+        message = self._capture(404, expected_statuses=frozenset({404}))[0].getMessage()
+        self.assertIn("not retryable", message)
+        self.assertNotIn("attempt 1/3", message)
+
+    def test_retryable_failure_still_counts_attempts(self) -> None:
+        records = self._capture(503)
+        self.assertIn("attempt 1/3", records[0].getMessage())
+        # Exhausting the retries is a real failure and keeps its ERROR.
+        self.assertEqual(records[-1].levelname, "ERROR")
+
+
+class TestDownloadAttachmentFile(unittest.TestCase):
+    def setUp(self) -> None:
+        self.client = ZoteroApiClient(zotero_user_id="123", api_key="k")
+
+    def test_404_becomes_file_not_stored(self) -> None:
+        with (
+            patch.object(self.client._session, "request") as request,
+            patch("app.integrations.zotero_api.time.sleep"),
+        ):
+            request.return_value = _response(404, "Not found")
+            with self.assertRaises(ZoteroFileNotStoredError):
+                self.client.download_attachment_file("ATT1")
+
+    def test_other_errors_are_not_reinterpreted(self) -> None:
+        """A 403 is a real access problem, not a missing-file condition."""
+        with (
+            patch.object(self.client._session, "request") as request,
+            patch("app.integrations.zotero_api.time.sleep"),
+        ):
+            request.return_value = _response(403, "Forbidden")
+            with self.assertRaises(requests.HTTPError):
+                self.client.download_attachment_file("ATT1")
+
+    def test_success_returns_content(self) -> None:
+        with patch.object(self.client._session, "request") as request:
+            request.return_value = _response(200)
+            self.assertEqual(
+                self.client.download_attachment_file("ATT1"), b"%PDF-1.4 body"
+            )
+
+
+class TestResolvePdfBytesFailureReason(unittest.TestCase):
+    def _resolve(self, download_side_effect):
+        client = MagicMock()
+        client.get_children.return_value = []
+        client.find_pdf_attachment.return_value = {
+            "key": "ATT1",
+            "data": {"linkMode": "imported_file", "contentType": "application/pdf"},
+        }
+        client.download_attachment_file.side_effect = download_side_effect
+        # No URLs to fall back to, so the attachment reason is what survives.
+        client.resolve_item_urls.return_value = []
+        return asyncio.run(_resolve_pdf_bytes(client, {"key": "ITEM1", "data": {}}))
+
+    def test_not_stored_reports_storage_guidance(self) -> None:
+        _, _, _, _, _, failure_reason = self._resolve(ZoteroFileNotStoredError("ATT1"))
+        self.assertEqual(failure_reason, FILE_NOT_STORED_MESSAGE)
+        # The reason has to name a recovery, not just the failure.
+        self.assertIn("In Zotero", failure_reason)
+
+    def test_other_failures_keep_the_generic_reason(self) -> None:
+        _, _, _, _, _, failure_reason = self._resolve(RuntimeError("boom"))
+        self.assertEqual(failure_reason, "PDF attachment download failed.")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
we see some errors coming from zotero for issues that aren't solvable on the server side - e.g., files not found on zotero. some analysis shows this could be due to files being stored in inaccessible locations (webdav). give the user an informative message and suppress the error on our side.

centralize the idea of retryable error codes. 